### PR TITLE
Improve metadata first load performance

### DIFF
--- a/gaseous-server/Classes/ImportGames.cs
+++ b/gaseous-server/Classes/ImportGames.cs
@@ -267,7 +267,7 @@ namespace gaseous_server.Classes
                     if (games.Length == 1)
                     {
                         // exact match!
-                        determinedGame = Metadata.Games.GetGame((long)games[0].Id, false, false);
+                        determinedGame = Metadata.Games.GetGame((long)games[0].Id, false, false, false);
                         Logging.Log(Logging.LogType.Information, "Import Game", "  IGDB game: " + determinedGame.Name);
                         GameFound = true;
                         break;
@@ -425,7 +425,7 @@ namespace gaseous_server.Classes
 
 			// get metadata
 			IGDB.Models.Platform platform = gaseous_server.Classes.Metadata.Platforms.GetPlatform(rom.PlatformId);
-			IGDB.Models.Game game = gaseous_server.Classes.Metadata.Games.GetGame(rom.GameId, false, false);
+			IGDB.Models.Game game = gaseous_server.Classes.Metadata.Games.GetGame(rom.GameId, false, false, false);
 
 			// build path
 			string platformSlug = "Unknown Platform";

--- a/gaseous-server/Classes/MetadataManagement.cs
+++ b/gaseous-server/Classes/MetadataManagement.cs
@@ -17,7 +17,7 @@ namespace gaseous_server.Classes
 				try
 				{
 					Logging.Log(Logging.LogType.Information, "Metadata Refresh", "Refreshing metadata for game " + dr["name"] + " (" + dr["id"] + ")");
-					Metadata.Games.GetGame((long)dr["id"], true, forceRefresh);
+					Metadata.Games.GetGame((long)dr["id"], true, true, forceRefresh);
 				}
 				catch (Exception ex)
 				{

--- a/gaseous-server/Classes/Roms.cs
+++ b/gaseous-server/Classes/Roms.cs
@@ -56,7 +56,7 @@ namespace gaseous_server.Classes
 			IGDB.Models.Platform platform = Classes.Metadata.Platforms.GetPlatform(PlatformId);
 
 			// ensure metadata for gameid is present
-			IGDB.Models.Game game = Classes.Metadata.Games.GetGame(GameId, false, false);
+			IGDB.Models.Game game = Classes.Metadata.Games.GetGame(GameId, false, false, false);
 
             Database db = new gaseous_tools.Database(Database.databaseType.MySql, Config.DatabaseConfiguration.ConnectionString);
             string sql = "UPDATE Games_Roms SET PlatformId=@platformid, GameId=@gameid WHERE Id = @id";

--- a/gaseous-server/Controllers/GamesController.cs
+++ b/gaseous-server/Controllers/GamesController.cs
@@ -136,7 +136,7 @@ namespace gaseous_server.Controllers
         {
             try
             {
-                IGDB.Models.Game gameObject = Classes.Metadata.Games.GetGame(GameId, false, forceRefresh);
+                IGDB.Models.Game gameObject = Classes.Metadata.Games.GetGame(GameId, forceRefresh, false, forceRefresh);
 
                 if (gameObject != null)
                 {
@@ -162,7 +162,7 @@ namespace gaseous_server.Controllers
         {
             try
             {
-                Game gameObject = Classes.Metadata.Games.GetGame(GameId, false, false);
+                Game gameObject = Classes.Metadata.Games.GetGame(GameId, false, false, false);
 
                 if (gameObject.AlternativeNames != null)
                 {
@@ -193,7 +193,7 @@ namespace gaseous_server.Controllers
         {
             try
             {
-                Game gameObject = Classes.Metadata.Games.GetGame(GameId, false, false);
+                Game gameObject = Classes.Metadata.Games.GetGame(GameId, false, false, false);
 
                 if (gameObject.AgeRatings != null)
                 {
@@ -303,7 +303,7 @@ namespace gaseous_server.Controllers
         {
             try
             {
-                Game gameObject = Classes.Metadata.Games.GetGame(GameId, false, false);
+                Game gameObject = Classes.Metadata.Games.GetGame(GameId, false, false, false);
 
                 List<Artwork> artworks = new List<Artwork>();
                 if (gameObject.Artworks != null)
@@ -332,7 +332,7 @@ namespace gaseous_server.Controllers
         {
             try
             {
-                IGDB.Models.Game gameObject = Classes.Metadata.Games.GetGame(GameId, false, false);
+                IGDB.Models.Game gameObject = Classes.Metadata.Games.GetGame(GameId, false, false, false);
 
                 try
                 {
@@ -365,7 +365,7 @@ namespace gaseous_server.Controllers
         {
             try
             {
-                IGDB.Models.Game gameObject = Classes.Metadata.Games.GetGame(GameId, false, false);
+                IGDB.Models.Game gameObject = Classes.Metadata.Games.GetGame(GameId, false, false, false);
 
                 try
                 {
@@ -420,7 +420,7 @@ namespace gaseous_server.Controllers
         {
             try
             {
-                IGDB.Models.Game gameObject = Classes.Metadata.Games.GetGame(GameId, false, false);
+                IGDB.Models.Game gameObject = Classes.Metadata.Games.GetGame(GameId, false, false, false);
                 if (gameObject != null)
                 {
                     IGDB.Models.Cover coverObject = Covers.GetCover(gameObject.Cover.Id, Config.LibraryConfiguration.LibraryMetadataDirectory_Game(gameObject));
@@ -452,7 +452,7 @@ namespace gaseous_server.Controllers
         {
             try
             {
-                IGDB.Models.Game gameObject = Classes.Metadata.Games.GetGame(GameId, false, false);
+                IGDB.Models.Game gameObject = Classes.Metadata.Games.GetGame(GameId, false, false, false);
 
                 string coverFilePath = Path.Combine(Config.LibraryConfiguration.LibraryMetadataDirectory_Game(gameObject), "Cover.png");
                 if (System.IO.File.Exists(coverFilePath)) {
@@ -492,7 +492,7 @@ namespace gaseous_server.Controllers
         {
             try
             {
-                IGDB.Models.Game gameObject = Classes.Metadata.Games.GetGame(GameId, false, false);
+                IGDB.Models.Game gameObject = Classes.Metadata.Games.GetGame(GameId, false, false, false);
                 if (gameObject != null)
                 {
                     List<IGDB.Models.Genre> genreObjects = new List<Genre>();
@@ -528,7 +528,7 @@ namespace gaseous_server.Controllers
         {
             try
             {
-                IGDB.Models.Game gameObject = Classes.Metadata.Games.GetGame(GameId, false, false);
+                IGDB.Models.Game gameObject = Classes.Metadata.Games.GetGame(GameId, false, false, false);
                 if (gameObject != null)
                 {
                     List<Dictionary<string, object>> icObjects = new List<Dictionary<string, object>>();
@@ -571,7 +571,7 @@ namespace gaseous_server.Controllers
         {
             try
             {
-                IGDB.Models.Game gameObject = Classes.Metadata.Games.GetGame(GameId, false, false);
+                IGDB.Models.Game gameObject = Classes.Metadata.Games.GetGame(GameId, false, false, false);
                 if (gameObject != null)
                 {
                     List<Dictionary<string, object>> icObjects = new List<Dictionary<string, object>>();
@@ -611,7 +611,7 @@ namespace gaseous_server.Controllers
         {
             try
             {
-                IGDB.Models.Game gameObject = Classes.Metadata.Games.GetGame(GameId, false, false);
+                IGDB.Models.Game gameObject = Classes.Metadata.Games.GetGame(GameId, false, false, false);
 
                 InvolvedCompany involvedCompany = Classes.Metadata.InvolvedCompanies.GetInvolvedCompanies(CompanyId);
                 Company company = Classes.Metadata.Companies.GetCompanies(involvedCompany.Company.Id);
@@ -655,7 +655,7 @@ namespace gaseous_server.Controllers
         {
             try
             {
-                Game gameObject = Classes.Metadata.Games.GetGame(GameId, false, false);
+                Game gameObject = Classes.Metadata.Games.GetGame(GameId, false, false, false);
 
                 List<Classes.Roms.GameRomItem> roms = Classes.Roms.GetRoms(GameId);
 
@@ -676,7 +676,7 @@ namespace gaseous_server.Controllers
         {
             try
             {
-                Game gameObject = Classes.Metadata.Games.GetGame(GameId, false, false);
+                Game gameObject = Classes.Metadata.Games.GetGame(GameId, false, false, false);
 
                 Classes.Roms.GameRomItem rom = Classes.Roms.GetRom(RomId);
                 if (rom.GameId == GameId)
@@ -702,7 +702,7 @@ namespace gaseous_server.Controllers
         {
             try
             {
-                Game gameObject = Classes.Metadata.Games.GetGame(GameId, false, false);
+                Game gameObject = Classes.Metadata.Games.GetGame(GameId, false, false, false);
 
                 Classes.Roms.GameRomItem rom = Classes.Roms.GetRom(RomId);
                 if (rom.GameId == GameId)
@@ -729,7 +729,7 @@ namespace gaseous_server.Controllers
         {
             try
             {
-                Game gameObject = Classes.Metadata.Games.GetGame(GameId, false, false);
+                Game gameObject = Classes.Metadata.Games.GetGame(GameId, false, false, false);
 
                 Classes.Roms.GameRomItem rom = Classes.Roms.GetRom(RomId);
                 if (rom.GameId == GameId)
@@ -757,7 +757,7 @@ namespace gaseous_server.Controllers
         {
             try
             {
-                IGDB.Models.Game gameObject = Classes.Metadata.Games.GetGame(GameId, false, false);
+                IGDB.Models.Game gameObject = Classes.Metadata.Games.GetGame(GameId, false, false, false);
 
                 Classes.Roms.GameRomItem rom = Classes.Roms.GetRom(RomId);
                 if (rom.GameId != GameId)
@@ -792,7 +792,7 @@ namespace gaseous_server.Controllers
         {
             try
             {
-                IGDB.Models.Game gameObject = Classes.Metadata.Games.GetGame(GameId, false, false);
+                IGDB.Models.Game gameObject = Classes.Metadata.Games.GetGame(GameId, false, false, false);
 
                 Classes.Roms.GameRomItem rom = Classes.Roms.GetRom(RomId);
                 if (rom.GameId != GameId || rom.Name != FileName)
@@ -864,7 +864,7 @@ namespace gaseous_server.Controllers
         {
             try
             {
-                Game gameObject = Classes.Metadata.Games.GetGame(GameId, false, false);
+                Game gameObject = Classes.Metadata.Games.GetGame(GameId, false, false, false);
 
                 List<Screenshot> screenshots = new List<Screenshot>();
                 if (gameObject.Screenshots != null)
@@ -893,7 +893,7 @@ namespace gaseous_server.Controllers
         {
             try
             { 
-                IGDB.Models.Game gameObject = Classes.Metadata.Games.GetGame(GameId, false, false);
+                IGDB.Models.Game gameObject = Classes.Metadata.Games.GetGame(GameId, false, false, false);
                 if (gameObject != null) { 
                     IGDB.Models.Screenshot screenshotObject = Screenshots.GetScreenshot(ScreenshotId, Config.LibraryConfiguration.LibraryMetadataDirectory_Game(gameObject));
                     if (screenshotObject != null)
@@ -924,7 +924,7 @@ namespace gaseous_server.Controllers
         {
             try
             {
-                IGDB.Models.Game gameObject = Classes.Metadata.Games.GetGame(GameId, false, false);
+                IGDB.Models.Game gameObject = Classes.Metadata.Games.GetGame(GameId, false, false, false);
 
                 IGDB.Models.Screenshot screenshotObject = Screenshots.GetScreenshot(ScreenshotId, Config.LibraryConfiguration.LibraryMetadataDirectory_Game(gameObject));
 
@@ -967,7 +967,7 @@ namespace gaseous_server.Controllers
         {
             try
             {
-                Game gameObject = Classes.Metadata.Games.GetGame(GameId, false, false);
+                Game gameObject = Classes.Metadata.Games.GetGame(GameId, false, false, false);
 
                 List<GameVideo> videos = new List<GameVideo>();
                 if (gameObject.Videos != null)

--- a/gaseous-server/Program.cs
+++ b/gaseous-server/Program.cs
@@ -114,7 +114,7 @@ app.MapControllers();
 Config.LibraryConfiguration.InitLibrary();
 
 // insert unknown platform and game if not present
-gaseous_server.Classes.Metadata.Games.GetGame(0, false, false);
+gaseous_server.Classes.Metadata.Games.GetGame(0, false, false, false);
 gaseous_server.Classes.Metadata.Platforms.GetPlatform(0);
 
 // organise library

--- a/gaseous-server/gaseous-server.csproj
+++ b/gaseous-server/gaseous-server.csproj
@@ -121,6 +121,9 @@
   <ItemGroup>
     <Content Remove="Support\PlatformMap.json" />
     <Content Remove="wwwroot\pages\settings\" />
+    <Content Remove="wwwroot\scripts\jquery.lazy.plugins.min.js" />
+    <Content Remove="wwwroot\scripts\jquery.lazy.min.js" />
+    <Content Remove="wwwroot\pages\dialogs\romsdelete.html" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="Support\PlatformMap.json" Condition="'$(ExcludeConfigFilesFromBuildOutput)'!='true'">


### PR DESCRIPTION
Pull only that metadata which is required during interactive sessions (during an import for example). The rest of the game metadata will be pull during a metadata refresh, or when the game page is loaded.