### PR TITLE
fix: Update not working after edit

### DIFF
--- a/gaseous-server/Classes/ImportGames.cs
+++ b/gaseous-server/Classes/ImportGames.cs
@@ -267,7 +267,7 @@ namespace gaseous_server.Classes
                     if (games.Length == 1)
                     {
                         // exact match!
-                        determinedGame = Metadata.Games.GetGame((long)games[0].Id, false, false);
+                        determinedGame = Metadata.Games.GetGame((long)games[0].Id, false, false, false);
                         Logging.Log(Logging.LogType.Information, "Import Game", "  IGDB game: " + determinedGame.Name);
                         GameFound = true;
                         break;
@@ -425,7 +425,7 @@ namespace gaseous_server.Classes
 
 			// get metadata
 			IGDB.Models.Platform platform = gaseous_server.Classes.Metadata.Platforms.GetPlatform(rom.PlatformId);
-			IGDB.Models.Game game = gaseous_server.Classes.Metadata.Games.GetGame(rom.GameId, false, false);
+			IGDB.Models.Game game = gaseous_server.Classes.Metadata.Games.GetGame(rom.GameId, false, false, false);
 
 			// build path
 			string platformSlug = "Unknown Platform";

--- a/gaseous-server/Classes/MetadataManagement.cs
+++ b/gaseous-server/Classes/MetadataManagement.cs
@@ -17,7 +17,7 @@ namespace gaseous_server.Classes
 				try
 				{
 					Logging.Log(Logging.LogType.Information, "Metadata Refresh", "Refreshing metadata for game " + dr["name"] + " (" + dr["id"] + ")");
-					Metadata.Games.GetGame((long)dr["id"], true, forceRefresh);
+					Metadata.Games.GetGame((long)dr["id"], true, true, forceRefresh);
 				}
 				catch (Exception ex)
 				{

--- a/gaseous-server/Classes/Roms.cs
+++ b/gaseous-server/Classes/Roms.cs
@@ -56,7 +56,7 @@ namespace gaseous_server.Classes
 			IGDB.Models.Platform platform = Classes.Metadata.Platforms.GetPlatform(PlatformId);
 
 			// ensure metadata for gameid is present
-			IGDB.Models.Game game = Classes.Metadata.Games.GetGame(GameId, false, false);
+			IGDB.Models.Game game = Classes.Metadata.Games.GetGame(GameId, false, false, false);
 
             Database db = new gaseous_tools.Database(Database.databaseType.MySql, Config.DatabaseConfiguration.ConnectionString);
             string sql = "UPDATE Games_Roms SET PlatformId=@platformid, GameId=@gameid WHERE Id = @id";

--- a/gaseous-server/Controllers/GamesController.cs
+++ b/gaseous-server/Controllers/GamesController.cs
@@ -136,7 +136,7 @@ namespace gaseous_server.Controllers
         {
             try
             {
-                IGDB.Models.Game gameObject = Classes.Metadata.Games.GetGame(GameId, false, forceRefresh);
+                IGDB.Models.Game gameObject = Classes.Metadata.Games.GetGame(GameId, forceRefresh, false, forceRefresh);
 
                 if (gameObject != null)
                 {
@@ -162,7 +162,7 @@ namespace gaseous_server.Controllers
         {
             try
             {
-                Game gameObject = Classes.Metadata.Games.GetGame(GameId, false, false);
+                Game gameObject = Classes.Metadata.Games.GetGame(GameId, false, false, false);
 
                 if (gameObject.AlternativeNames != null)
                 {
@@ -193,7 +193,7 @@ namespace gaseous_server.Controllers
         {
             try
             {
-                Game gameObject = Classes.Metadata.Games.GetGame(GameId, false, false);
+                Game gameObject = Classes.Metadata.Games.GetGame(GameId, false, false, false);
 
                 if (gameObject.AgeRatings != null)
                 {
@@ -303,7 +303,7 @@ namespace gaseous_server.Controllers
         {
             try
             {
-                Game gameObject = Classes.Metadata.Games.GetGame(GameId, false, false);
+                Game gameObject = Classes.Metadata.Games.GetGame(GameId, false, false, false);
 
                 List<Artwork> artworks = new List<Artwork>();
                 if (gameObject.Artworks != null)
@@ -332,7 +332,7 @@ namespace gaseous_server.Controllers
         {
             try
             {
-                IGDB.Models.Game gameObject = Classes.Metadata.Games.GetGame(GameId, false, false);
+                IGDB.Models.Game gameObject = Classes.Metadata.Games.GetGame(GameId, false, false, false);
 
                 try
                 {
@@ -365,7 +365,7 @@ namespace gaseous_server.Controllers
         {
             try
             {
-                IGDB.Models.Game gameObject = Classes.Metadata.Games.GetGame(GameId, false, false);
+                IGDB.Models.Game gameObject = Classes.Metadata.Games.GetGame(GameId, false, false, false);
 
                 try
                 {
@@ -420,7 +420,7 @@ namespace gaseous_server.Controllers
         {
             try
             {
-                IGDB.Models.Game gameObject = Classes.Metadata.Games.GetGame(GameId, false, false);
+                IGDB.Models.Game gameObject = Classes.Metadata.Games.GetGame(GameId, false, false, false);
                 if (gameObject != null)
                 {
                     IGDB.Models.Cover coverObject = Covers.GetCover(gameObject.Cover.Id, Config.LibraryConfiguration.LibraryMetadataDirectory_Game(gameObject));
@@ -452,7 +452,7 @@ namespace gaseous_server.Controllers
         {
             try
             {
-                IGDB.Models.Game gameObject = Classes.Metadata.Games.GetGame(GameId, false, false);
+                IGDB.Models.Game gameObject = Classes.Metadata.Games.GetGame(GameId, false, false, false);
 
                 string coverFilePath = Path.Combine(Config.LibraryConfiguration.LibraryMetadataDirectory_Game(gameObject), "Cover.png");
                 if (System.IO.File.Exists(coverFilePath)) {
@@ -492,7 +492,7 @@ namespace gaseous_server.Controllers
         {
             try
             {
-                IGDB.Models.Game gameObject = Classes.Metadata.Games.GetGame(GameId, false, false);
+                IGDB.Models.Game gameObject = Classes.Metadata.Games.GetGame(GameId, false, false, false);
                 if (gameObject != null)
                 {
                     List<IGDB.Models.Genre> genreObjects = new List<Genre>();
@@ -528,7 +528,7 @@ namespace gaseous_server.Controllers
         {
             try
             {
-                IGDB.Models.Game gameObject = Classes.Metadata.Games.GetGame(GameId, false, false);
+                IGDB.Models.Game gameObject = Classes.Metadata.Games.GetGame(GameId, false, false, false);
                 if (gameObject != null)
                 {
                     List<Dictionary<string, object>> icObjects = new List<Dictionary<string, object>>();
@@ -571,7 +571,7 @@ namespace gaseous_server.Controllers
         {
             try
             {
-                IGDB.Models.Game gameObject = Classes.Metadata.Games.GetGame(GameId, false, false);
+                IGDB.Models.Game gameObject = Classes.Metadata.Games.GetGame(GameId, false, false, false);
                 if (gameObject != null)
                 {
                     List<Dictionary<string, object>> icObjects = new List<Dictionary<string, object>>();
@@ -611,7 +611,7 @@ namespace gaseous_server.Controllers
         {
             try
             {
-                IGDB.Models.Game gameObject = Classes.Metadata.Games.GetGame(GameId, false, false);
+                IGDB.Models.Game gameObject = Classes.Metadata.Games.GetGame(GameId, false, false, false);
 
                 InvolvedCompany involvedCompany = Classes.Metadata.InvolvedCompanies.GetInvolvedCompanies(CompanyId);
                 Company company = Classes.Metadata.Companies.GetCompanies(involvedCompany.Company.Id);
@@ -655,7 +655,7 @@ namespace gaseous_server.Controllers
         {
             try
             {
-                Game gameObject = Classes.Metadata.Games.GetGame(GameId, false, false);
+                Game gameObject = Classes.Metadata.Games.GetGame(GameId, false, false, false);
 
                 List<Classes.Roms.GameRomItem> roms = Classes.Roms.GetRoms(GameId);
 
@@ -676,7 +676,7 @@ namespace gaseous_server.Controllers
         {
             try
             {
-                Game gameObject = Classes.Metadata.Games.GetGame(GameId, false, false);
+                Game gameObject = Classes.Metadata.Games.GetGame(GameId, false, false, false);
 
                 Classes.Roms.GameRomItem rom = Classes.Roms.GetRom(RomId);
                 if (rom.GameId == GameId)
@@ -702,7 +702,7 @@ namespace gaseous_server.Controllers
         {
             try
             {
-                Game gameObject = Classes.Metadata.Games.GetGame(GameId, false, false);
+                Game gameObject = Classes.Metadata.Games.GetGame(GameId, false, false, false);
 
                 Classes.Roms.GameRomItem rom = Classes.Roms.GetRom(RomId);
                 if (rom.GameId == GameId)
@@ -729,7 +729,7 @@ namespace gaseous_server.Controllers
         {
             try
             {
-                Game gameObject = Classes.Metadata.Games.GetGame(GameId, false, false);
+                Game gameObject = Classes.Metadata.Games.GetGame(GameId, false, false, false);
 
                 Classes.Roms.GameRomItem rom = Classes.Roms.GetRom(RomId);
                 if (rom.GameId == GameId)
@@ -757,7 +757,7 @@ namespace gaseous_server.Controllers
         {
             try
             {
-                IGDB.Models.Game gameObject = Classes.Metadata.Games.GetGame(GameId, false, false);
+                IGDB.Models.Game gameObject = Classes.Metadata.Games.GetGame(GameId, false, false, false);
 
                 Classes.Roms.GameRomItem rom = Classes.Roms.GetRom(RomId);
                 if (rom.GameId != GameId)
@@ -792,7 +792,7 @@ namespace gaseous_server.Controllers
         {
             try
             {
-                IGDB.Models.Game gameObject = Classes.Metadata.Games.GetGame(GameId, false, false);
+                IGDB.Models.Game gameObject = Classes.Metadata.Games.GetGame(GameId, false, false, false);
 
                 Classes.Roms.GameRomItem rom = Classes.Roms.GetRom(RomId);
                 if (rom.GameId != GameId || rom.Name != FileName)
@@ -864,7 +864,7 @@ namespace gaseous_server.Controllers
         {
             try
             {
-                Game gameObject = Classes.Metadata.Games.GetGame(GameId, false, false);
+                Game gameObject = Classes.Metadata.Games.GetGame(GameId, false, false, false);
 
                 List<Screenshot> screenshots = new List<Screenshot>();
                 if (gameObject.Screenshots != null)
@@ -893,7 +893,7 @@ namespace gaseous_server.Controllers
         {
             try
             { 
-                IGDB.Models.Game gameObject = Classes.Metadata.Games.GetGame(GameId, false, false);
+                IGDB.Models.Game gameObject = Classes.Metadata.Games.GetGame(GameId, false, false, false);
                 if (gameObject != null) { 
                     IGDB.Models.Screenshot screenshotObject = Screenshots.GetScreenshot(ScreenshotId, Config.LibraryConfiguration.LibraryMetadataDirectory_Game(gameObject));
                     if (screenshotObject != null)
@@ -924,7 +924,7 @@ namespace gaseous_server.Controllers
         {
             try
             {
-                IGDB.Models.Game gameObject = Classes.Metadata.Games.GetGame(GameId, false, false);
+                IGDB.Models.Game gameObject = Classes.Metadata.Games.GetGame(GameId, false, false, false);
 
                 IGDB.Models.Screenshot screenshotObject = Screenshots.GetScreenshot(ScreenshotId, Config.LibraryConfiguration.LibraryMetadataDirectory_Game(gameObject));
 
@@ -967,7 +967,7 @@ namespace gaseous_server.Controllers
         {
             try
             {
-                Game gameObject = Classes.Metadata.Games.GetGame(GameId, false, false);
+                Game gameObject = Classes.Metadata.Games.GetGame(GameId, false, false, false);
 
                 List<GameVideo> videos = new List<GameVideo>();
                 if (gameObject.Videos != null)

--- a/gaseous-server/Program.cs
+++ b/gaseous-server/Program.cs
@@ -114,7 +114,7 @@ app.MapControllers();
 Config.LibraryConfiguration.InitLibrary();
 
 // insert unknown platform and game if not present
-gaseous_server.Classes.Metadata.Games.GetGame(0, false, false);
+gaseous_server.Classes.Metadata.Games.GetGame(0, false, false, false);
 gaseous_server.Classes.Metadata.Platforms.GetPlatform(0);
 
 // organise library

--- a/gaseous-server/gaseous-server.csproj
+++ b/gaseous-server/gaseous-server.csproj
@@ -121,6 +121,9 @@
   <ItemGroup>
     <Content Remove="Support\PlatformMap.json" />
     <Content Remove="wwwroot\pages\settings\" />
+    <Content Remove="wwwroot\scripts\jquery.lazy.plugins.min.js" />
+    <Content Remove="wwwroot\scripts\jquery.lazy.min.js" />
+    <Content Remove="wwwroot\pages\dialogs\romsdelete.html" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="Support\PlatformMap.json" Condition="'$(ExcludeConfigFilesFromBuildOutput)'!='true'">

--- a/gaseous-server/wwwroot/pages/game.html
+++ b/gaseous-server/wwwroot/pages/game.html
@@ -2,6 +2,19 @@
     <div id="bgImage_Opacity"></div>
 </div>
 
+<!-- The Modal -->
+<div id="myModalProgress" class="modal">
+
+    <!-- Modal content -->
+    <div class="modal-content-sub">
+        <div id="modal-content-sub-progress">
+            <h1>In Progress...</h1>
+            <progress style="width: 100%;"></progress>
+        </div>
+    </div>
+
+</div>
+
 <div id="gamepage">
     <div id="gametitle">
         <h1 id="gametitle_label"></h1>
@@ -60,10 +73,9 @@
         </div>
     </div>
 
-    
+
 </div>
-<script type="text/javascript">
-    var gameId = getQueryString('id', 'int');
+<script type="text/javascript">var gameId = getQueryString('id', 'int');
     var gameData;
     var artworks = null;
     var artworksPosition = 0;
@@ -104,7 +116,7 @@
             } else {
                 gameSummaryLabel.innerHTML = result.storyline;
             }
-            
+
             if (gameSummaryLabel.offsetHeight < gameSummaryLabel.scrollHeight ||
                 gameSummaryLabel.offsetWidth < gameSummaryLabel.scrollWidth) {
                 // your element has overflow and truncated
@@ -140,7 +152,7 @@
             ajaxCall('/api/v1/games/' + gameId + '/companies', 'GET', function (result) {
                 var lstDevelopers = [];
                 var lstPublishers = [];
-                
+
                 for (var i = 0; i < result.length; i++) {
                     var companyLabel = document.createElement('span');
                     companyLabel.className = 'gamegenrelabel';
@@ -231,7 +243,7 @@
         var gameScreenshots = document.getElementById('gamescreenshots');
         if (result.screenshots || result.videos) {
             var gameScreenshots_Main = document.getElementById('gamescreenshots_main');
-            
+
             // load static screenshots
             var gameScreenshots_Gallery = document.getElementById('gamescreenshots_gallery_panel');
             var imageIndex = 0;
@@ -344,7 +356,7 @@
 
                     var newRow = [
                         ['<input type="checkbox" name="rom_checkbox" data-romid="' + result[i].id + '" />', 'rom_checkbox_box_hidden', 'rom_edit_checkbox'],
-                        '<a href="/api/v1/Games/' + gameId + '/roms/' + result[i].id + '/' + encodeURIComponent(result[i].name) +'" class="romlink">' + result[i].name + '</a>',
+                        '<a href="/api/v1/Games/' + gameId + '/roms/' + result[i].id + '/' + encodeURIComponent(result[i].name) + '" class="romlink">' + result[i].name + '</a>',
                         formatBytes(result[i].size, 2),
                         result[i].romTypeMedia,
                         result[i].mediaLabel,
@@ -433,7 +445,7 @@
         var gameScreenshots_Items = document.getElementsByName('gamescreenshots_gallery_item');
 
         selectedScreenshot = selectedScreenshot - 1;
-        
+
         if (selectedScreenshot < 0) {
             selectedScreenshot = gameScreenshots_Items.length - 1;
         }
@@ -545,17 +557,30 @@
     });
 
     var remapCallCounter = 0;
+    var remapCallCounterMax = 0;
     function remapTitles() {
         var fixplatform = $('#rom_edit_fixplatform').select2('data');
         var fixgame = $('#rom_edit_fixgame').select2('data');
 
         if (fixplatform[0] && fixgame[0]) {
             var rom_checks = document.getElementsByName('rom_checkbox');
+
+            for (var i = 0; i < rom_checks.length; i++) {
+                if (rom_checks[i].checked == true) {
+                    remapCallCounterMax += 1;
+                }
+            }
+
+            showProgress();
+
             for (var i = 0; i < rom_checks.length; i++) {
                 if (rom_checks[i].checked == true) {
                     var romId = rom_checks[i].getAttribute('data-romid');
                     remapCallCounter += 1;
+
                     ajaxCall('/api/v1/Games/' + gameId + '/roms/' + romId + '?NewPlatformId=' + fixplatform[0].id + '&NewGameId=' + fixgame[0].id, 'PATCH', function (result) {
+                        remapTitlesCallback();
+                    }, function (result) {
                         remapTitlesCallback();
                     });
                 }
@@ -565,9 +590,12 @@
 
     function remapTitlesCallback() {
         remapCallCounter = remapCallCounter - 1;
+
         if (remapCallCounter <= 0) {
+            closeProgress();
             loadRoms(true);
             remapCallCounter = 0;
+            remapCallCounterMax = 0;
         }
     }
 
@@ -589,6 +617,8 @@
         var rom_checks = document.getElementsByName('rom_checkbox');
         for (var i = 0; i < rom_checks.length; i++) {
             if (rom_checks[i].checked == true) {
+                remapCallCounterMax += 1;
+
                 var romId = rom_checks[i].getAttribute('data-romid');
                 remapCallCounter += 1;
                 ajaxCall('/api/v1/Games/' + gameId + '/roms/' + romId, 'DELETE', function (result) {
@@ -597,4 +627,19 @@
             }
         }
     }
-</script>
+
+    function showProgress() {
+        // Get the modal
+        var submodal = document.getElementById("myModalProgress");
+
+        // When the user clicks on the button, open the modal 
+        submodal.style.display = "block";
+    }
+
+    function closeProgress() {
+        // Get the modal
+        var submodal = document.getElementById("myModalProgress");
+
+        submodal.style.display = "none";
+    }
+    </script>

--- a/gaseous-server/wwwroot/scripts/main.js
+++ b/gaseous-server/wwwroot/scripts/main.js
@@ -1,4 +1,4 @@
-﻿function ajaxCall(endpoint, method, successFunction) {
+﻿function ajaxCall(endpoint, method, successFunction, errorFunction) {
     $.ajax({
 
         // Our sample url to make request
@@ -11,14 +11,18 @@
         // Function to call when to
         // request is ok
         success: function (data) {
-            var x = JSON.stringify(data);
-            console.log(x);
+            //var x = JSON.stringify(data);
+            //console.log(x);
             successFunction(data);
         },
 
         // Error handling
         error: function (error) {
             console.log(`Error ${error}`);
+
+            if (errorFunction) {
+                errorFunction(error);
+            }
         }
     });
 }
@@ -210,4 +214,8 @@ function DropDownRenderGameOption(state) {
         );
     }
     return response;
+}
+
+function sleep(ms) {
+    return new Promise(resolve => setTimeout(resolve, ms));
 }

--- a/gaseous-server/wwwroot/styles/style.css
+++ b/gaseous-server/wwwroot/styles/style.css
@@ -771,3 +771,15 @@ button:disabled {
     -webkit-box-shadow: 5px 5px 19px 0px rgba(0,0,0,0.44);
     -moz-box-shadow: 5px 5px 19px 0px rgba(0,0,0,0.44);
 }
+
+#rom_edit_progressbar {
+    width: 100%;
+    height: 10px;
+    background-color: lightgray;
+    margin-top: 10px;
+}
+
+#rom_edit_progressbar_progress {
+    height: 10px;
+    background-color: cyan;
+}


### PR DESCRIPTION
Bulk update was hanging when assigning ROMs to a game with no metadata - fetching metadata was taking too long.

Backported a fix that speeds up metadata fetching, and now display a dialog while the process is running.