### PR TITLE
Provide a platform override option during web based import

### DIFF
--- a/gaseous-server/Controllers/RomsController.cs
+++ b/gaseous-server/Controllers/RomsController.cs
@@ -25,7 +25,7 @@ namespace gaseous_server.Controllers
         [ProducesResponseType(typeof(List<IFormFile>), StatusCodes.Status200OK)]
         [RequestSizeLimit(long.MaxValue)]
         [DisableRequestSizeLimit, RequestFormLimits(MultipartBodyLengthLimit = long.MaxValue, ValueLengthLimit = int.MaxValue)]
-        public async Task<IActionResult> UploadRom(List<IFormFile> files)
+        public async Task<IActionResult> UploadRom(List<IFormFile> files, long? OverridePlatformId = null)
         {
             Guid sessionid = Guid.NewGuid();
 
@@ -61,12 +61,17 @@ namespace gaseous_server.Controllers
                 }
             }
 
-            // Process uploaded files
-            // Don't rely on or trust the FileName property without validation.
+            // get override platform if specified
+            IGDB.Models.Platform? OverridePlatform = null;
+            if (OverridePlatformId != null)
+            {
+                OverridePlatform = Platforms.GetPlatform((long)OverridePlatformId);
+            }
 
+            // Process uploaded files
             foreach (Dictionary<string, object> UploadedFile in UploadedFiles)
             {
-                Classes.ImportGame.ImportGameFile((string)UploadedFile["fullpath"]);
+                Classes.ImportGame.ImportGameFile((string)UploadedFile["fullpath"], OverridePlatform, false);
             }
 
             if (Directory.Exists(workPath))

--- a/gaseous-server/wwwroot/pages/dialogs/upload.html
+++ b/gaseous-server/wwwroot/pages/dialogs/upload.html
@@ -12,9 +12,20 @@
 <div>
     <div id="upload_target" class="dropzone"></div>
 </div>
+<table style="width: 100%;">
+    <tr>
+        <th style="width: 40%;">
+            Override automatic platform detection:
+        </th>
+        <td style="width: 60%;">
+            <select id="upload_platformoverride" style="width: 100%;"></select>
+        </td>
+    </tr>
+</table>
 
 <script type="text/javascript">
     document.getElementById('modal-heading').innerHTML = "Upload";
+    document.getElementById('upload_platformoverride').innerHTML = "<option value='0' selected='selected'>Automatic Platform</option>";
 
     var myDropzone = new Dropzone("div#upload_target", {
         url: "/api/v1/Roms",
@@ -69,4 +80,51 @@
         subModalContent.innerHTML = "";
         subModalVariables = null;
     }
+
+    $('#upload_platformoverride').select2({
+        minimumInputLength: 3,
+        ajax: {
+            url: '/api/v1/Search/Platform',
+            data: function (params) {
+                var query = {
+                    SearchString: params.term
+                }
+
+                // Query parameters will be ?SearchString=[term]
+                return query;
+            },
+            processResults: function (data) {
+                var arr = [];
+
+                // insert automatic detection item
+                arr.push({
+                    id: 0,
+                    text: "Automatic Platform"
+                });
+
+                for (var i = 0; i < data.length; i++) {
+                    arr.push({
+                        id: data[i].id,
+                        text: data[i].name
+                    });
+                }
+
+                return {
+                    results: arr
+                };
+
+            }
+        }
+    });
+
+    $('#upload_platformoverride').on('select2:select', function (e) {
+        var platformOverride = $('#upload_platformoverride').select2('data');
+        var queryString = '';
+        if (Number(platformOverride[0].id) != 0) {
+            queryString = "?OverridePlatformId=" + platformOverride[0].id;
+        }
+        console.log(queryString);
+
+        myDropzone.options.url = "/api/v1/Roms" + queryString;
+    });
 </script>


### PR DESCRIPTION
Use the drop down to select the platform you want to use, the selection will apply on the next upload.

Change it back to automatic by selecting "Automatic Platform".

Note that importing via the ~/.gaseous-server/Data/Import does not support platform overrides.

<img width="746" alt="Screenshot 2023-09-10 at 11 22 15 am" src="https://github.com/gaseous-project/gaseous-server/assets/84688932/3ae5b064-13e7-4b2a-a0ad-53f9c78d30ba">