### PR TITLE
Fail safe when the IGDB connector experiences an exception

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -16,8 +16,10 @@ If you expose the server to the internet, **you do so at your own risk**.
 ![Emulator](./screenshots/Emulator.png)
 
 ## Requirements
-* MySQL Server 8+
+* MySQL Server 8+*
 * Internet Game Database API Key. See: https://api-docs.igdb.com/#account-creation
+
+***Note**: MariaDB is currently not supported as Gaseous uses features present only in MySQL. This is being tracked in https://github.com/gaseous-project/gaseous-server/issues/93
 
 ## Third Party Projects
 The following projects are used by Gaseous
@@ -89,7 +91,7 @@ Dockerfile and docker-compose-build.yml files have been provided to make deploym
 
 ## Source
 ### Build and deploy
-1. Install and configure a MySQL or MariaDB instance
+1. Install and configure a MySQL instance
 2. Install the dotnet 7.0 packages appropriate for your operating system
     * See: https://learn.microsoft.com/en-us/dotnet/core/install/linux
 3. Create a database user with permission to create a databse. Gaseous will create the new database and apply the database schema on it's first startup.

--- a/gaseous-server/Classes/Metadata/AgeRating.cs
+++ b/gaseous-server/Classes/Metadata/AgeRating.cs
@@ -77,10 +77,17 @@ namespace gaseous_server.Classes.Metadata
                     UpdateSubClasses(returnValue);
                     break;  
                 case Storage.CacheStatus.Expired:
-                    returnValue = await GetObjectFromServer(WhereClause);
-                    Storage.NewCacheValue(returnValue, true);
-                    UpdateSubClasses(returnValue);
-                    break;  
+                    try
+                    {
+                        returnValue = await GetObjectFromServer(WhereClause);
+                        Storage.NewCacheValue(returnValue, true);
+                    }
+                    catch (Exception ex)
+                    {
+                        gaseous_tools.Logging.Log(gaseous_tools.Logging.LogType.Warning, "Metadata: " + returnValue.GetType().Name, "An error occurred while connecting to IGDB. WhereClause: " + WhereClause, ex);
+                        returnValue = Storage.GetCacheValue<AgeRating>(returnValue, "id", (long)searchValue);
+                    }
+                    break;
                 case Storage.CacheStatus.Current:
                     returnValue = Storage.GetCacheValue<AgeRating>(returnValue, "id", (long)searchValue);
                     break;

--- a/gaseous-server/Classes/Metadata/AgeRatingContentDescriptions.cs
+++ b/gaseous-server/Classes/Metadata/AgeRatingContentDescriptions.cs
@@ -75,9 +75,17 @@ namespace gaseous_server.Classes.Metadata
                     Storage.NewCacheValue(returnValue);
                     break;  
                 case Storage.CacheStatus.Expired:
-                    returnValue = await GetObjectFromServer(WhereClause);
-                    Storage.NewCacheValue(returnValue, true);
-                    break;  
+                    try
+                    {
+                        returnValue = await GetObjectFromServer(WhereClause);
+                        Storage.NewCacheValue(returnValue, true);
+                    }
+                    catch (Exception ex)
+                    {
+                        gaseous_tools.Logging.Log(gaseous_tools.Logging.LogType.Warning, "Metadata: " + returnValue.GetType().Name, "An error occurred while connecting to IGDB. WhereClause: " + WhereClause, ex);
+                        returnValue = Storage.GetCacheValue<AgeRatingContentDescription>(returnValue, "id", (long)searchValue);
+                    }
+                    break;
                 case Storage.CacheStatus.Current:
                     returnValue = Storage.GetCacheValue<AgeRatingContentDescription>(returnValue, "id", (long)searchValue);
                     break;

--- a/gaseous-server/Classes/Metadata/AlternativeNames.cs
+++ b/gaseous-server/Classes/Metadata/AlternativeNames.cs
@@ -75,9 +75,17 @@ namespace gaseous_server.Classes.Metadata
                     Storage.NewCacheValue(returnValue);
                     break;  
                 case Storage.CacheStatus.Expired:
-                    returnValue = await GetObjectFromServer(WhereClause);
-                    Storage.NewCacheValue(returnValue, true);
-                    break;  
+                    try
+                    {
+                        returnValue = await GetObjectFromServer(WhereClause);
+                        Storage.NewCacheValue(returnValue, true);
+                    }
+                    catch (Exception ex)
+                    {
+                        gaseous_tools.Logging.Log(gaseous_tools.Logging.LogType.Warning, "Metadata: " + returnValue.GetType().Name, "An error occurred while connecting to IGDB. WhereClause: " + WhereClause, ex);
+                        returnValue = Storage.GetCacheValue<AlternativeName>(returnValue, "id", (long)searchValue);
+                    }
+                    break;
                 case Storage.CacheStatus.Current:
                     returnValue = Storage.GetCacheValue<AlternativeName>(returnValue, "id", (long)searchValue);
                     break;

--- a/gaseous-server/Classes/Metadata/Artworks.cs
+++ b/gaseous-server/Classes/Metadata/Artworks.cs
@@ -78,10 +78,17 @@ namespace gaseous_server.Classes.Metadata
                     forceImageDownload = true;
                     break;  
                 case Storage.CacheStatus.Expired:
-                    returnValue = await GetObjectFromServer(WhereClause, LogoPath);
-                    Storage.NewCacheValue(returnValue, true);
-                    forceImageDownload = true;
-                    break;  
+                    try
+                    {
+                        returnValue = await GetObjectFromServer(WhereClause, LogoPath);
+                        Storage.NewCacheValue(returnValue, true);
+                    }
+                    catch (Exception ex)
+                    {
+                        gaseous_tools.Logging.Log(gaseous_tools.Logging.LogType.Warning, "Metadata: " + returnValue.GetType().Name, "An error occurred while connecting to IGDB. WhereClause: " + WhereClause, ex);
+                        returnValue = Storage.GetCacheValue<Artwork>(returnValue, "id", (long)searchValue);
+                    }
+                    break;
                 case Storage.CacheStatus.Current:
                     returnValue = Storage.GetCacheValue<Artwork>(returnValue, "id", (long)searchValue);
                     break;

--- a/gaseous-server/Classes/Metadata/Collections.cs
+++ b/gaseous-server/Classes/Metadata/Collections.cs
@@ -75,9 +75,17 @@ namespace gaseous_server.Classes.Metadata
                     Storage.NewCacheValue(returnValue);
                     break;  
                 case Storage.CacheStatus.Expired:
-                    returnValue = await GetObjectFromServer(WhereClause);
-                    Storage.NewCacheValue(returnValue, true);
-                    break;  
+                    try
+                    {
+                        returnValue = await GetObjectFromServer(WhereClause);
+                        Storage.NewCacheValue(returnValue, true);
+                    }
+                    catch (Exception ex)
+                    {
+                        gaseous_tools.Logging.Log(gaseous_tools.Logging.LogType.Warning, "Metadata: " + returnValue.GetType().Name, "An error occurred while connecting to IGDB. WhereClause: " + WhereClause, ex);
+                        returnValue = Storage.GetCacheValue<Collection>(returnValue, "id", (long)searchValue);
+                    }
+                    break;
                 case Storage.CacheStatus.Current:
                     returnValue = Storage.GetCacheValue<Collection>(returnValue, "id", (long)searchValue);
                     break;

--- a/gaseous-server/Classes/Metadata/Company.cs
+++ b/gaseous-server/Classes/Metadata/Company.cs
@@ -74,9 +74,16 @@ namespace gaseous_server.Classes.Metadata
                     UpdateSubClasses(returnValue);
                     break;
                 case Storage.CacheStatus.Expired:
-                    returnValue = await GetObjectFromServer(WhereClause);
-                    if (returnValue != null) { Storage.NewCacheValue(returnValue, true); }
-                    UpdateSubClasses(returnValue);
+                    try
+                    {
+                        returnValue = await GetObjectFromServer(WhereClause);
+                        Storage.NewCacheValue(returnValue, true);
+                    }
+                    catch (Exception ex)
+                    {
+                        gaseous_tools.Logging.Log(gaseous_tools.Logging.LogType.Warning, "Metadata: " + returnValue.GetType().Name, "An error occurred while connecting to IGDB. WhereClause: " + WhereClause, ex);
+                        returnValue = Storage.GetCacheValue<Company>(returnValue, "id", (long)searchValue);
+                    }
                     break;
                 case Storage.CacheStatus.Current:
                     returnValue = Storage.GetCacheValue<Company>(returnValue, "id", (long)searchValue);

--- a/gaseous-server/Classes/Metadata/CompanyLogos.cs
+++ b/gaseous-server/Classes/Metadata/CompanyLogos.cs
@@ -80,11 +80,16 @@ namespace gaseous_server.Classes.Metadata
                     }
                     break;
                 case Storage.CacheStatus.Expired:
-                    returnValue = await GetObjectFromServer(WhereClause, LogoPath);
-                    if (returnValue != null)
+                    try
                     {
+                        returnValue = await GetObjectFromServer(WhereClause, LogoPath);
                         Storage.NewCacheValue(returnValue, true);
                         forceImageDownload = true;
+                    }
+                    catch (Exception ex)
+                    {
+                        gaseous_tools.Logging.Log(gaseous_tools.Logging.LogType.Warning, "Metadata: " + returnValue.GetType().Name, "An error occurred while connecting to IGDB. WhereClause: " + WhereClause, ex);
+                        returnValue = Storage.GetCacheValue<CompanyLogo>(returnValue, "id", (long)searchValue);
                     }
                     break;
                 case Storage.CacheStatus.Current:

--- a/gaseous-server/Classes/Metadata/Covers.cs
+++ b/gaseous-server/Classes/Metadata/Covers.cs
@@ -77,10 +77,18 @@ namespace gaseous_server.Classes.Metadata
                     forceImageDownload = true;
                     break;  
                 case Storage.CacheStatus.Expired:
-                    returnValue = await GetObjectFromServer(WhereClause, LogoPath);
-                    Storage.NewCacheValue(returnValue, true);
-                    forceImageDownload = true;
-                    break;  
+                    try
+                    {
+                        returnValue = await GetObjectFromServer(WhereClause, LogoPath);
+                        Storage.NewCacheValue(returnValue, true);
+                        forceImageDownload = true;
+                    }
+                    catch (Exception ex)
+                    {
+                        gaseous_tools.Logging.Log(gaseous_tools.Logging.LogType.Warning, "Metadata: " + returnValue.GetType().Name, "An error occurred while connecting to IGDB. WhereClause: " + WhereClause, ex);
+                        returnValue = Storage.GetCacheValue<Cover>(returnValue, "id", (long)searchValue);
+                    }
+                    break;
                 case Storage.CacheStatus.Current:
                     returnValue = Storage.GetCacheValue<Cover>(returnValue, "id", (long)searchValue);
                     break;

--- a/gaseous-server/Classes/Metadata/ExternalGames.cs
+++ b/gaseous-server/Classes/Metadata/ExternalGames.cs
@@ -78,12 +78,17 @@ namespace gaseous_server.Classes.Metadata
                     }
                     break;  
                 case Storage.CacheStatus.Expired:
-                    returnValue = await GetObjectFromServer(WhereClause);
-                    if (returnValue != null)
+                    try
                     {
+                        returnValue = await GetObjectFromServer(WhereClause);
                         Storage.NewCacheValue(returnValue, true);
                     }
-                    break;  
+                    catch (Exception ex)
+                    {
+                        gaseous_tools.Logging.Log(gaseous_tools.Logging.LogType.Warning, "Metadata: " + returnValue.GetType().Name, "An error occurred while connecting to IGDB. WhereClause: " + WhereClause, ex);
+                        returnValue = Storage.GetCacheValue<ExternalGame>(returnValue, "id", (long)searchValue);
+                    }
+                    break;
                 case Storage.CacheStatus.Current:
                     returnValue = Storage.GetCacheValue<ExternalGame>(returnValue, "id", (long)searchValue);
                     break;

--- a/gaseous-server/Classes/Metadata/Franchises.cs
+++ b/gaseous-server/Classes/Metadata/Franchises.cs
@@ -75,9 +75,17 @@ namespace gaseous_server.Classes.Metadata
                     Storage.NewCacheValue(returnValue);
                     break;  
                 case Storage.CacheStatus.Expired:
-                    returnValue = await GetObjectFromServer(WhereClause);
-                    Storage.NewCacheValue(returnValue, true);
-                    break;  
+                    try
+                    {
+                        returnValue = await GetObjectFromServer(WhereClause);
+                        Storage.NewCacheValue(returnValue, true);
+                    }
+                    catch (Exception ex)
+                    {
+                        gaseous_tools.Logging.Log(gaseous_tools.Logging.LogType.Warning, "Metadata: " + returnValue.GetType().Name, "An error occurred while connecting to IGDB. WhereClause: " + WhereClause, ex);
+                        returnValue = Storage.GetCacheValue<Franchise>(returnValue, "id", (long)searchValue);
+                    }
+                    break;
                 case Storage.CacheStatus.Current:
                     returnValue = Storage.GetCacheValue<Franchise>(returnValue, "id", (long)searchValue);
                     break;

--- a/gaseous-server/Classes/Metadata/GameModes.cs
+++ b/gaseous-server/Classes/Metadata/GameModes.cs
@@ -68,18 +68,23 @@ namespace gaseous_server.Classes.Metadata
             }
 
             GameMode returnValue = new GameMode();
-            bool forceImageDownload = false;
             switch (cacheStatus)
             {
                 case Storage.CacheStatus.NotPresent:
                     returnValue = await GetObjectFromServer(WhereClause);
                     Storage.NewCacheValue(returnValue);
-                    forceImageDownload = true;
                     break;
                 case Storage.CacheStatus.Expired:
-                    returnValue = await GetObjectFromServer(WhereClause);
-                    Storage.NewCacheValue(returnValue, true);
-                    forceImageDownload = true;
+                    try
+                    {
+                        returnValue = await GetObjectFromServer(WhereClause);
+                        Storage.NewCacheValue(returnValue, true);
+                    }
+                    catch (Exception ex)
+                    {
+                        gaseous_tools.Logging.Log(gaseous_tools.Logging.LogType.Warning, "Metadata: " + returnValue.GetType().Name, "An error occurred while connecting to IGDB. WhereClause: " + WhereClause, ex);
+                        returnValue = Storage.GetCacheValue<GameMode>(returnValue, "id", (long)searchValue);
+                    }
                     break;
                 case Storage.CacheStatus.Current:
                     returnValue = Storage.GetCacheValue<GameMode>(returnValue, "id", (long)searchValue);

--- a/gaseous-server/Classes/Metadata/GameVideos.cs
+++ b/gaseous-server/Classes/Metadata/GameVideos.cs
@@ -68,19 +68,24 @@ namespace gaseous_server.Classes.Metadata
             }
 
             GameVideo returnValue = new GameVideo();
-            bool forceImageDownload = false;
             switch (cacheStatus)
             {
                 case Storage.CacheStatus.NotPresent:
                     returnValue = await GetObjectFromServer(WhereClause);
                     Storage.NewCacheValue(returnValue);
-                    forceImageDownload = true;
                     break;  
                 case Storage.CacheStatus.Expired:
-                    returnValue = await GetObjectFromServer(WhereClause);
-                    Storage.NewCacheValue(returnValue, true);
-                    forceImageDownload = true;
-                    break;  
+                    try
+                    {
+                        returnValue = await GetObjectFromServer(WhereClause);
+                        Storage.NewCacheValue(returnValue, true);
+                    }
+                    catch (Exception ex)
+                    {
+                        gaseous_tools.Logging.Log(gaseous_tools.Logging.LogType.Warning, "Metadata: " + returnValue.GetType().Name, "An error occurred while connecting to IGDB. WhereClause: " + WhereClause, ex);
+                        returnValue = Storage.GetCacheValue<GameVideo>(returnValue, "id", (long)searchValue);
+                    }
+                    break;
                 case Storage.CacheStatus.Current:
                     returnValue = Storage.GetCacheValue<GameVideo>(returnValue, "id", (long)searchValue);
                     break;

--- a/gaseous-server/Classes/Metadata/Games.cs
+++ b/gaseous-server/Classes/Metadata/Games.cs
@@ -102,9 +102,16 @@ namespace gaseous_server.Classes.Metadata
                     UpdateSubClasses(returnValue, getAllMetadata, followSubGames);
                     return returnValue;
                 case Storage.CacheStatus.Expired:
-                    returnValue = await GetObjectFromServer(WhereClause);
-                    Storage.NewCacheValue(returnValue, true);
-                    UpdateSubClasses(returnValue, getAllMetadata, followSubGames);
+                    try
+                    {
+                        returnValue = await GetObjectFromServer(WhereClause);
+                        Storage.NewCacheValue(returnValue, true);
+                    }
+                    catch (Exception ex)
+                    {
+                        gaseous_tools.Logging.Log(gaseous_tools.Logging.LogType.Warning, "Metadata: " + returnValue.GetType().Name, "An error occurred while connecting to IGDB. WhereClause: " + WhereClause, ex);
+                        returnValue = Storage.GetCacheValue<Game>(returnValue, "id", (long)searchValue);
+                    }
                     return returnValue;
                 case Storage.CacheStatus.Current:
                     return Storage.GetCacheValue<Game>(returnValue, "id", (long)searchValue);

--- a/gaseous-server/Classes/Metadata/Genres.cs
+++ b/gaseous-server/Classes/Metadata/Genres.cs
@@ -68,19 +68,24 @@ namespace gaseous_server.Classes.Metadata
             }
 
             Genre returnValue = new Genre();
-            bool forceImageDownload = false;
             switch (cacheStatus)
             {
                 case Storage.CacheStatus.NotPresent:
                     returnValue = await GetObjectFromServer(WhereClause);
                     Storage.NewCacheValue(returnValue);
-                    forceImageDownload = true;
                     break;  
                 case Storage.CacheStatus.Expired:
-                    returnValue = await GetObjectFromServer(WhereClause);
-                    Storage.NewCacheValue(returnValue, true);
-                    forceImageDownload = true;
-                    break;  
+                    try
+                    {
+                        returnValue = await GetObjectFromServer(WhereClause);
+                        Storage.NewCacheValue(returnValue, true);
+                    }
+                    catch (Exception ex)
+                    {
+                        gaseous_tools.Logging.Log(gaseous_tools.Logging.LogType.Warning, "Metadata: " + returnValue.GetType().Name, "An error occurred while connecting to IGDB. WhereClause: " + WhereClause, ex);
+                        returnValue = Storage.GetCacheValue<Genre>(returnValue, "id", (long)searchValue);
+                    }
+                    break;
                 case Storage.CacheStatus.Current:
                     returnValue = Storage.GetCacheValue<Genre>(returnValue, "id", (long)searchValue);
                     break;

--- a/gaseous-server/Classes/Metadata/InvolvedCompany.cs
+++ b/gaseous-server/Classes/Metadata/InvolvedCompany.cs
@@ -74,9 +74,16 @@ namespace gaseous_server.Classes.Metadata
                     UpdateSubClasses(returnValue);
                     break;
                 case Storage.CacheStatus.Expired:
-                    returnValue = await GetObjectFromServer(WhereClause);
-                    Storage.NewCacheValue(returnValue, true);
-                    UpdateSubClasses(returnValue);
+                    try
+                    {
+                        returnValue = await GetObjectFromServer(WhereClause);
+                        Storage.NewCacheValue(returnValue, true);
+                    }
+                    catch (Exception ex)
+                    {
+                        gaseous_tools.Logging.Log(gaseous_tools.Logging.LogType.Warning, "Metadata: " + returnValue.GetType().Name, "An error occurred while connecting to IGDB. WhereClause: " + WhereClause, ex);
+                        returnValue = Storage.GetCacheValue<InvolvedCompany>(returnValue, "id", (long)searchValue);
+                    }
                     break;
                 case Storage.CacheStatus.Current:
                     returnValue = Storage.GetCacheValue<InvolvedCompany>(returnValue, "id", (long)searchValue);

--- a/gaseous-server/Classes/Metadata/MultiplayerModes.cs
+++ b/gaseous-server/Classes/Metadata/MultiplayerModes.cs
@@ -68,18 +68,23 @@ namespace gaseous_server.Classes.Metadata
             }
 
             MultiplayerMode returnValue = new MultiplayerMode();
-            bool forceImageDownload = false;
             switch (cacheStatus)
             {
                 case Storage.CacheStatus.NotPresent:
                     returnValue = await GetObjectFromServer(WhereClause);
                     Storage.NewCacheValue(returnValue);
-                    forceImageDownload = true;
                     break;
                 case Storage.CacheStatus.Expired:
-                    returnValue = await GetObjectFromServer(WhereClause);
-                    Storage.NewCacheValue(returnValue, true);
-                    forceImageDownload = true;
+                    try
+                    {
+                        returnValue = await GetObjectFromServer(WhereClause);
+                        Storage.NewCacheValue(returnValue, true);
+                    }
+                    catch (Exception ex)
+                    {
+                        gaseous_tools.Logging.Log(gaseous_tools.Logging.LogType.Warning, "Metadata: " + returnValue.GetType().Name, "An error occurred while connecting to IGDB. WhereClause: " + WhereClause, ex);
+                        returnValue = Storage.GetCacheValue<MultiplayerMode>(returnValue, "id", (long)searchValue);
+                    }
                     break;
                 case Storage.CacheStatus.Current:
                     returnValue = Storage.GetCacheValue<MultiplayerMode>(returnValue, "id", (long)searchValue);

--- a/gaseous-server/Classes/Metadata/PlatformLogos.cs
+++ b/gaseous-server/Classes/Metadata/PlatformLogos.cs
@@ -80,11 +80,16 @@ namespace gaseous_server.Classes.Metadata
                     }
                     break;  
                 case Storage.CacheStatus.Expired:
-                    returnValue = await GetObjectFromServer(WhereClause, LogoPath);
-                    if (returnValue != null)
+                    try
                     {
+                        returnValue = await GetObjectFromServer(WhereClause, LogoPath);
                         Storage.NewCacheValue(returnValue, true);
                         forceImageDownload = true;
+                    }
+                    catch (Exception ex)
+                    {
+                        gaseous_tools.Logging.Log(gaseous_tools.Logging.LogType.Warning, "Metadata: " + returnValue.GetType().Name, "An error occurred while connecting to IGDB. WhereClause: " + WhereClause, ex);
+                        returnValue = Storage.GetCacheValue<PlatformLogo>(returnValue, "id", (long)searchValue);
                     }
                     break;  
                 case Storage.CacheStatus.Current:

--- a/gaseous-server/Classes/Metadata/PlatformVersions.cs
+++ b/gaseous-server/Classes/Metadata/PlatformVersions.cs
@@ -78,11 +78,16 @@ namespace gaseous_server.Classes.Metadata
                     }
                     return returnValue;
                 case Storage.CacheStatus.Expired:
-                    returnValue = await GetObjectFromServer(WhereClause);
-                    if (returnValue != null)
+                    try
                     {
+                        returnValue = await GetObjectFromServer(WhereClause);
                         Storage.NewCacheValue(returnValue, true);
                         UpdateSubClasses(ParentPlatform, returnValue);
+                    }
+                    catch (Exception ex)
+                    {
+                        gaseous_tools.Logging.Log(gaseous_tools.Logging.LogType.Warning, "Metadata: " + returnValue.GetType().Name, "An error occurred while connecting to IGDB. WhereClause: " + WhereClause, ex);
+                        returnValue = Storage.GetCacheValue<PlatformVersion>(returnValue, "id", (long)searchValue);
                     }
                     return returnValue;
                 case Storage.CacheStatus.Current:

--- a/gaseous-server/Classes/Metadata/Platforms.cs
+++ b/gaseous-server/Classes/Metadata/Platforms.cs
@@ -99,11 +99,19 @@ namespace gaseous_server.Classes.Metadata
                     AddPlatformMapping(returnValue);
                     return returnValue;
                 case Storage.CacheStatus.Expired:
-                    returnValue = await GetObjectFromServer(WhereClause);
-                    Storage.NewCacheValue(returnValue, true);
-                    UpdateSubClasses(returnValue);
-                    AddPlatformMapping(returnValue);
-                    return returnValue;
+                    try
+                    {
+                        returnValue = await GetObjectFromServer(WhereClause);
+                        Storage.NewCacheValue(returnValue, true);
+                        UpdateSubClasses(returnValue);
+                        AddPlatformMapping(returnValue);
+                        return returnValue;
+                    }
+                    catch (Exception ex)
+                    {
+                        Logging.Log(Logging.LogType.Warning, "Metadata: " + returnValue.GetType().Name, "An error occurred while connecting to IGDB. WhereClause: " + WhereClause, ex);
+                        return Storage.GetCacheValue<Platform>(returnValue, "id", (long)searchValue);
+                    }
                 case Storage.CacheStatus.Current:
                     return Storage.GetCacheValue<Platform>(returnValue, "id", (long)searchValue);
                 default:

--- a/gaseous-server/Classes/Metadata/PlayerPerspectives.cs
+++ b/gaseous-server/Classes/Metadata/PlayerPerspectives.cs
@@ -77,9 +77,16 @@ namespace gaseous_server.Classes.Metadata
                     forceImageDownload = true;
                     break;
                 case Storage.CacheStatus.Expired:
-                    returnValue = await GetObjectFromServer(WhereClause);
-                    Storage.NewCacheValue(returnValue, true);
-                    forceImageDownload = true;
+                    try
+                    {
+                        returnValue = await GetObjectFromServer(WhereClause);
+                        Storage.NewCacheValue(returnValue, true);
+                    }
+                    catch (Exception ex)
+                    {
+                        gaseous_tools.Logging.Log(gaseous_tools.Logging.LogType.Warning, "Metadata: " + returnValue.GetType().Name, "An error occurred while connecting to IGDB. WhereClause: " + WhereClause, ex);
+                        returnValue = Storage.GetCacheValue<PlayerPerspective>(returnValue, "id", (long)searchValue);
+                    }
                     break;
                 case Storage.CacheStatus.Current:
                     returnValue = Storage.GetCacheValue<PlayerPerspective>(returnValue, "id", (long)searchValue);

--- a/gaseous-server/Classes/Metadata/Screenshots.cs
+++ b/gaseous-server/Classes/Metadata/Screenshots.cs
@@ -78,10 +78,18 @@ namespace gaseous_server.Classes.Metadata
                     forceImageDownload = true;
                     break;  
                 case Storage.CacheStatus.Expired:
-                    returnValue = await GetObjectFromServer(WhereClause, LogoPath);
-                    Storage.NewCacheValue(returnValue, true);
-                    forceImageDownload = true;
-                    break;  
+                    try
+                    {
+                        returnValue = await GetObjectFromServer(WhereClause, LogoPath);
+                        Storage.NewCacheValue(returnValue, true);
+                        forceImageDownload = true;
+                    }
+                    catch (Exception ex)
+                    {
+                        gaseous_tools.Logging.Log(gaseous_tools.Logging.LogType.Warning, "Metadata: " + returnValue.GetType().Name, "An error occurred while connecting to IGDB. WhereClause: " + WhereClause, ex);
+                        returnValue = Storage.GetCacheValue<Screenshot>(returnValue, "id", (long)searchValue);
+                    }
+                    break;
                 case Storage.CacheStatus.Current:
                     returnValue = Storage.GetCacheValue<Screenshot>(returnValue, "id", (long)searchValue);
                     break;

--- a/gaseous-server/Classes/Metadata/Themes.cs
+++ b/gaseous-server/Classes/Metadata/Themes.cs
@@ -77,10 +77,17 @@ namespace gaseous_server.Classes.Metadata
                     forceImageDownload = true;
                     break;
                 case Storage.CacheStatus.Expired:
-                    returnValue = await GetObjectFromServer(WhereClause);
-                    Storage.NewCacheValue(returnValue, true);
-                    forceImageDownload = true;
-                    break;
+                    try
+                    {
+                        returnValue = await GetObjectFromServer(WhereClause);
+                        Storage.NewCacheValue(returnValue, true);
+                        return returnValue;
+                    }
+                    catch (Exception ex)
+                    {
+                        gaseous_tools.Logging.Log(gaseous_tools.Logging.LogType.Warning, "Metadata: " + returnValue.GetType().Name, "An error occurred while connecting to IGDB. WhereClause: " + WhereClause, ex);
+                        return Storage.GetCacheValue<Theme>(returnValue, "id", (long)searchValue);
+                    }
                 case Storage.CacheStatus.Current:
                     returnValue = Storage.GetCacheValue<Theme>(returnValue, "id", (long)searchValue);
                     break;


### PR DESCRIPTION
If an error occurs when updating metadata from IGDB, the exception is now logged and any cached value is returned.