### PR TITLE
Split LibraryScan and Rematching into separate background tasks

### DIFF
--- a/gaseous-server/Models/PlatformMapping.cs
+++ b/gaseous-server/Models/PlatformMapping.cs
@@ -4,6 +4,7 @@ using System.Data;
 using System.Linq;
 using System.Reflection;
 using System.Text.Json.Serialization;
+using System.Web;
 using gaseous_server.Classes;
 using gaseous_server.Classes.Metadata;
 using gaseous_server.Controllers;
@@ -201,7 +202,7 @@ namespace gaseous_server.Models
                         sql = "INSERT INTO PlatformMap_AlternateNames (Id, Name) VALUES (@Id, @Name);";
                         dbDict.Clear();
                         dbDict.Add("Id", item.IGDBId);
-                        dbDict.Add("Name", alternateName);
+                        dbDict.Add("Name", HttpUtility.HtmlDecode(alternateName));
                         db.ExecuteCMD(sql, dbDict);
                     }
                 }

--- a/gaseous-server/ProcessQueue.cs
+++ b/gaseous-server/ProcessQueue.cs
@@ -146,6 +146,14 @@ namespace gaseous_server
 
                                     break;
 
+                                case QueueItemType.Rematcher:
+                                    Logging.Log(Logging.LogType.Debug, "Timered Event", "Starting Rematch");
+                                    Classes.ImportGame.Rematcher();
+
+                                    _SaveLastRunTime = true;
+
+                                    break;
+
                                 case QueueItemType.CollectionCompiler:
                                     Logging.Log(Logging.LogType.Debug, "Timered Event", "Starting Collection Compiler");
                                     Classes.Collections.CompileCollections((long)Options);
@@ -168,6 +176,8 @@ namespace gaseous_server
                         _ForceExecute = false;
                         _ItemState = QueueItemState.Stopped;
                         _LastFinishTime = DateTime.UtcNow;
+
+                        Logging.Log(Logging.LogType.Information, "Timered Event", "Total " + _ItemType + " run time = " + (DateTime.UtcNow - _LastRunTime).TotalSeconds);
                     }
                 }
             }
@@ -219,6 +229,11 @@ namespace gaseous_server
             /// Looks for orphaned files in the library and re-adds them to the database
             /// </summary>
             LibraryScan,
+
+            /// <summary>
+            /// Looks for roms in the library that have an unknown platform or game match
+            /// </summary>
+            Rematcher,
 
             /// <summary>
             /// Builds collections - set the options attribute to the id of the collection to build

--- a/gaseous-server/Program.cs
+++ b/gaseous-server/Program.cs
@@ -207,7 +207,8 @@ ProcessQueue.QueueItems.Add(new ProcessQueue.QueueItem(
     new List<ProcessQueue.QueueItemType>
     {
         ProcessQueue.QueueItemType.LibraryScan,
-        ProcessQueue.QueueItemType.TitleIngestor
+        ProcessQueue.QueueItemType.TitleIngestor,
+        ProcessQueue.QueueItemType.Rematcher
     })
     );
 ProcessQueue.QueueItems.Add(new ProcessQueue.QueueItem(

--- a/gaseous-server/Program.cs
+++ b/gaseous-server/Program.cs
@@ -182,29 +182,53 @@ gaseous_server.Classes.Metadata.Platforms.GetPlatform(0);
 PlatformMapping.ExtractPlatformMap();
 
 // add background tasks
-ProcessQueue.QueueItems.Add(new ProcessQueue.QueueItem(ProcessQueue.QueueItemType.SignatureIngestor, 60));
 ProcessQueue.QueueItems.Add(new ProcessQueue.QueueItem(
-    ProcessQueue.QueueItemType.TitleIngestor, 1,
+    ProcessQueue.QueueItemType.SignatureIngestor,
+    60
+    )
+    );
+ProcessQueue.QueueItems.Add(new ProcessQueue.QueueItem(
+    ProcessQueue.QueueItemType.TitleIngestor,
+    1,
     new List<ProcessQueue.QueueItemType>
     {
         ProcessQueue.QueueItemType.OrganiseLibrary,
         ProcessQueue.QueueItemType.LibraryScan
     })
     );
-ProcessQueue.QueueItems.Add(new ProcessQueue.QueueItem(ProcessQueue.QueueItemType.MetadataRefresh, 360));
 ProcessQueue.QueueItems.Add(new ProcessQueue.QueueItem(
-    ProcessQueue.QueueItemType.OrganiseLibrary, 1440, new List<ProcessQueue.QueueItemType>
+    ProcessQueue.QueueItemType.MetadataRefresh,
+    360
+    )
+    );
+ProcessQueue.QueueItems.Add(new ProcessQueue.QueueItem(
+    ProcessQueue.QueueItemType.OrganiseLibrary,
+    1440,
+    new List<ProcessQueue.QueueItemType>
     {
         ProcessQueue.QueueItemType.LibraryScan,
         ProcessQueue.QueueItemType.TitleIngestor
     })
     );
 ProcessQueue.QueueItems.Add(new ProcessQueue.QueueItem(
-    ProcessQueue.QueueItemType.LibraryScan, 1440, new List<ProcessQueue.QueueItemType>
+    ProcessQueue.QueueItemType.LibraryScan,
+    60,
+    new List<ProcessQueue.QueueItemType>
     {
-        ProcessQueue.QueueItemType.OrganiseLibrary
+        ProcessQueue.QueueItemType.OrganiseLibrary,
+        ProcessQueue.QueueItemType.Rematcher
     })
     );
+ProcessQueue.QueueItems.Add(new ProcessQueue.QueueItem(
+    ProcessQueue.QueueItemType.Rematcher,
+    1440,
+    new List<ProcessQueue.QueueItemType>
+    {
+        ProcessQueue.QueueItemType.OrganiseLibrary,
+        ProcessQueue.QueueItemType.LibraryScan
+    })
+    );
+
 
 Logging.WriteToDiskOnly = false;
 

--- a/gaseous-server/Support/PlatformMap.json
+++ b/gaseous-server/Support/PlatformMap.json
@@ -882,7 +882,7 @@
         "alternateNames": [
             "NES",
             "Nintendo Entertainment System",
-            "Nintendo Famicom &amp;amp; Entertainment System"
+            "Nintendo Famicom & Entertainment System"
         ],
         "extensions": {
             "supportedFileExtensions": [
@@ -1086,7 +1086,7 @@
         "alternateNames": [
             "Mega CD",
             "Sega CD",
-            "Sega Mega-CD &amp;amp; Sega CD",
+            "Sega Mega-CD & Sega CD",
             "segacd"
         ],
         "extensions": {
@@ -1188,7 +1188,7 @@
         "igdbName": "Sega Master System/Mark III",
         "igdbSlug": "sms",
         "alternateNames": [
-            "Sega Mark III &amp;amp; Master System",
+            "Sega Mark III & Master System",
             "Sega Master System",
             "Sega Master System/Mark III",
             "sms",
@@ -1248,7 +1248,7 @@
             "genesis-slash-megadrive",
             "Sega Genesis",
             "Sega Mega Drive",
-            "Sega Mega Drive &amp; Genesis",
+            "Sega Mega Drive & Genesis",
             "Sega Mega Drive/Genesis"
         ],
         "extensions": {
@@ -1351,7 +1351,7 @@
         "igdbName": "Super Nintendo Entertainment System",
         "igdbSlug": "snes",
         "alternateNames": [
-            "Nintendo Super Famicom &amp;amp; Super Entertainment System",
+            "Nintendo Super Famicom & Super Entertainment System",
             "SNES",
             "SNES, Super Nintendo",
             "Super Nintendo",

--- a/gaseous-tools/Database/MySQL/gaseous-1004.sql
+++ b/gaseous-tools/Database/MySQL/gaseous-1004.sql
@@ -37,3 +37,6 @@ CREATE TABLE `Relation_Game_Themes` (
   PRIMARY KEY (`GameId`, `ThemesId`),
   INDEX `idx_PrimaryColumn` (`GameId` ASC) VISIBLE
 );
+
+ALTER TABLE `Games_Roms` 
+ADD COLUMN `LastMatchAttemptDate` DATETIME NULL AFTER `LibraryId`;


### PR DESCRIPTION
Removed the rematching task from LibraryScan - this process now only has one job: to ensure the database is consistent with what's on disk.

Created a new task called Rematcher - it runs once a day (every 1440 minutes), and only on a limited subset of targets. It selects the first 100 ROM's which have a platform or a game of unknown, AND who's last rematch date was more than 30 days ago (or NULL).