### PR TITLE
Migrate existing collections to new user on first run after upgrade to 1.7

### DIFF
--- a/gaseous-server/Controllers/V1.1/FirstSetupController.cs
+++ b/gaseous-server/Controllers/V1.1/FirstSetupController.cs
@@ -71,6 +71,15 @@ namespace gaseous_server.Controllers
                         Logging.Log(Logging.LogType.Information, "First Run", "Setting first run state to 1");
                         Config.SetSetting<string>("FirstRunStatus", "1");
 
+                        Logging.Log(Logging.LogType.Information, "First Run", "Migrating existing collections to newly created user (for upgrades from v1.6.1 and earlier)");
+                        Database db = new Database(Database.databaseType.MySql, Config.DatabaseConfiguration.ConnectionString);
+                        string sql = "UPDATE RomCollections SET OwnedBy=@userid WHERE OwnedBy IS NULL;";
+                        Dictionary<string, object> dbDict = new Dictionary<string, object>
+                        {
+                            { "userid", user.Id }
+                        };
+                        db.ExecuteCMD(sql, dbDict);
+
                         return Ok(result);
                     }
                     else


### PR DESCRIPTION
As 1.7 is the first version with user authentication, existing collections need to be migrated to a user or they are not visible.

With this change, existing collections are migrated to the newly created user during first run.