### PR TITLE
Update for PlatformMap.json to add missing core support

### DIFF
--- a/gaseous-server/Support/PlatformMap.json
+++ b/gaseous-server/Support/PlatformMap.json
@@ -1,1864 +1,3834 @@
 [
-    {
-        "igdbId": 50,
-        "igdbName": "3DO Interactive Multiplayer",
-        "igdbSlug": "3do",
-        "alternateNames": [
-            "3DO",
-            "3DO Interactive Multiplayer"
-        ],
-        "extensions": {
-            "supportedFileExtensions": [
-                ".CHD",
-                ".CUE",
-                ".ISO",
-                ".ZIP"
-            ],
-            "uniqueFileExtensions": []
-        },
-        "retroPieDirectoryName": "3do",
-        "webEmulator": {
-            "type": "EmulatorJS",
-            "core": "3do",
-            "availableWebEmulators": [
-                {
-                    "emulatorType": "EmulatorJS",
-                    "availableWebEmulatorCores": [
-                        {
-                            "core": "3do",
-                            "alternateCoreName": "opera",
-                            "default": true
-                        }
-                    ]
-                }
-            ]
-        },
-        "bios": [
+  {
+    "IGDBId": 139,
+    "IGDBName": "1292 Advanced Programmable Video System",
+    "IGDBSlug": "1292-advanced-programmable-video-system",
+    "AlternateNames": [],
+    "Extensions": {
+      "SupportedFileExtensions": [],
+      "UniqueFileExtensions": []
+    },
+    "RetroPieDirectoryName": "",
+    "WebEmulator": {
+      "Type": "",
+      "Core": "",
+      "AvailableWebEmulators": null
+    },
+    "Bios": []
+  },
+  {
+    "IGDBId": 50,
+    "IGDBName": "3DO Interactive Multiplayer",
+    "IGDBSlug": "3do",
+    "AlternateNames": [
+      "3DO",
+      "3DO Interactive Multiplayer"
+    ],
+    "Extensions": {
+      "SupportedFileExtensions": [
+        ".CHD",
+        ".CUE",
+        ".ISO",
+        ".ZIP"
+      ],
+      "UniqueFileExtensions": []
+    },
+    "RetroPieDirectoryName": "3do",
+    "WebEmulator": {
+      "Type": "EmulatorJS",
+      "Core": "3do",
+      "AvailableWebEmulators": [
+        {
+          "EmulatorType": "EmulatorJS",
+          "AvailableWebEmulatorCores": [
             {
-                "hash": "8970fc987ab89a7f64da9f8a8c4333ff",
-                "description": "Shootout At Old Tucson",
-                "filename": "3do_arcade_saot.bin"
-            },
-            {
-                "hash": "8639fd5e549bd6238cfee79e3e749114",
-                "description": "Goldstar GDO-101M",
-                "filename": "goldstar.bin"
-            },
-            {
-                "hash": "f47264dd47fe30f73ab3c010015c155b",
-                "description": "Panasonic FZ-1",
-                "filename": "panafz1.bin"
-            },
-            {
-                "hash": "1477bda80dc33731a65468c1f5bcbee9",
-                "description": "Panasonic FZ-10 [RSA Patch]",
-                "filename": "panafz10-norsa.bin"
-            },
-            {
-                "hash": "51f2f43ae2f3508a14d9f56597e2d3ce",
-                "description": "Panasonic FZ-10",
-                "filename": "panafz10.bin"
-            },
-            {
-                "hash": "cf11bbb5a16d7af9875cca9de9a15e09",
-                "description": "Panasonic FZ-10-E [Anvil RSA Patch]",
-                "filename": "panafz10e-anvil-norsa.bin"
-            },
-            {
-                "hash": "a48e6746bd7edec0f40cff078f0bb19f",
-                "description": "Panasonic FZ-10-E [Anvil]",
-                "filename": "panafz10e-anvil.bin"
-            },
-            {
-                "hash": "f6c71de7470d16abe4f71b1444883dc8",
-                "description": "Panasonic FZ-1J [RSA Patch]",
-                "filename": "panafz1j-norsa.bin"
-            },
-            {
-                "hash": "a496cfdded3da562759be3561317b605",
-                "description": "Panasonic FZ-1J",
-                "filename": "panafz1j.bin"
-            },
-            {
-                "hash": "35fa1a1ebaaeea286dc5cd15487c13ea",
-                "description": "Sanyo IMP-21J TRY",
-                "filename": "sanyotry.bin"
+              "Core": "3do",
+              "AlternateCoreName": "opera",
+              "Default": true
             }
-        ]
+          ]
+        }
+      ]
     },
-    {
-        "igdbId": 16,
-        "igdbName": "Amiga",
-        "igdbSlug": "amiga",
-        "alternateNames": [
-            "Amiga",
-            "Commodore Amiga"
-        ],
-        "extensions": {
-            "supportedFileExtensions": [
-                ".ADF",
-                ".ADZ",
-                ".DMS",
-                ".FDI",
-                ".HDF",
-                ".HDZ",
-                ".IPF",
-                ".LHA",
-                ".UAE",
-                ".ZIP"
-            ],
-            "uniqueFileExtensions": [
-                ".ADF",
-                ".ADZ",
-                ".DMS",
-                ".FDI",
-                ".HDF",
-                ".HDZ",
-                ".LHA",
-                ".UAE"
-            ]
-        },
-        "retroPieDirectoryName": "amiga",
-        "webEmulator": {
-            "type": "EmulatorJS",
-            "core": "amiga",
-            "availableWebEmulators": [
-                {
-                    "emulatorType": "EmulatorJS",
-                    "availableWebEmulatorCores": [
-                        {
-                            "core": "amiga",
-                            "alternateCoreName": "puae",
-                            "default": true
-                        }
-                    ]
-                }
-            ]
-        },
-        "bios": [
+    "Bios": [
+      {
+        "hash": "8970fc987ab89a7f64da9f8a8c4333ff",
+        "description": "Shootout At Old Tucson",
+        "filename": "3do_arcade_saot.bin"
+      },
+      {
+        "hash": "8639fd5e549bd6238cfee79e3e749114",
+        "description": "Goldstar GDO-101M",
+        "filename": "goldstar.bin"
+      },
+      {
+        "hash": "f47264dd47fe30f73ab3c010015c155b",
+        "description": "Panasonic FZ-1",
+        "filename": "panafz1.bin"
+      },
+      {
+        "hash": "1477bda80dc33731a65468c1f5bcbee9",
+        "description": "Panasonic FZ-10 [RSA Patch]",
+        "filename": "panafz10-norsa.bin"
+      },
+      {
+        "hash": "51f2f43ae2f3508a14d9f56597e2d3ce",
+        "description": "Panasonic FZ-10",
+        "filename": "panafz10.bin"
+      },
+      {
+        "hash": "cf11bbb5a16d7af9875cca9de9a15e09",
+        "description": "Panasonic FZ-10-E [Anvil RSA Patch]",
+        "filename": "panafz10e-anvil-norsa.bin"
+      },
+      {
+        "hash": "a48e6746bd7edec0f40cff078f0bb19f",
+        "description": "Panasonic FZ-10-E [Anvil]",
+        "filename": "panafz10e-anvil.bin"
+      },
+      {
+        "hash": "f6c71de7470d16abe4f71b1444883dc8",
+        "description": "Panasonic FZ-1J [RSA Patch]",
+        "filename": "panafz1j-norsa.bin"
+      },
+      {
+        "hash": "a496cfdded3da562759be3561317b605",
+        "description": "Panasonic FZ-1J",
+        "filename": "panafz1j.bin"
+      },
+      {
+        "hash": "35fa1a1ebaaeea286dc5cd15487c13ea",
+        "description": "Sanyo IMP-21J TRY",
+        "filename": "sanyotry.bin"
+      }
+    ]
+  },
+  {
+    "IGDBId": 116,
+    "IGDBName": "Acorn Archimedes",
+    "IGDBSlug": "acorn-archimedes",
+    "AlternateNames": [],
+    "Extensions": {
+      "SupportedFileExtensions": [],
+      "UniqueFileExtensions": []
+    },
+    "RetroPieDirectoryName": "",
+    "WebEmulator": {
+      "Type": "",
+      "Core": "",
+      "AvailableWebEmulators": null
+    },
+    "Bios": []
+  },
+  {
+    "IGDBId": 134,
+    "IGDBName": "Acorn Electron",
+    "IGDBSlug": "acorn-electron",
+    "AlternateNames": [],
+    "Extensions": {
+      "SupportedFileExtensions": [],
+      "UniqueFileExtensions": []
+    },
+    "RetroPieDirectoryName": "",
+    "WebEmulator": {
+      "Type": "",
+      "Core": "",
+      "AvailableWebEmulators": null
+    },
+    "Bios": []
+  },
+  {
+    "IGDBId": 16,
+    "IGDBName": "Amiga",
+    "IGDBSlug": "amiga",
+    "AlternateNames": [
+      "Amiga",
+      "Commodore Amiga"
+    ],
+    "Extensions": {
+      "SupportedFileExtensions": [
+        ".ADF",
+        ".ADZ",
+        ".DMS",
+        ".FDI",
+        ".HDF",
+        ".HDZ",
+        ".IPF",
+        ".LHA",
+        ".UAE",
+        ".ZIP"
+      ],
+      "UniqueFileExtensions": [
+        ".ADF",
+        ".ADZ",
+        ".DMS",
+        ".FDI",
+        ".HDF",
+        ".HDZ",
+        ".LHA",
+        ".UAE"
+      ]
+    },
+    "RetroPieDirectoryName": "amiga",
+    "WebEmulator": {
+      "Type": "EmulatorJS",
+      "Core": "amiga",
+      "AvailableWebEmulators": [
+        {
+          "EmulatorType": "EmulatorJS",
+          "AvailableWebEmulatorCores": [
             {
-                "hash": "85ad74194e87c08904327de1a9443b7a",
-                "description": "Kickstart v1.2 rev 33.180",
-                "filename": "kick33180.A500"
-            },
-            {
-                "hash": "82a21c1890cae844b3df741f2762d48d",
-                "description": "Kickstart v1.3 rev 34.005",
-                "filename": "kick34005.A500"
-            },
-            {
-                "hash": "89da1838a24460e4b93f4f0c5d92d48d",
-                "description": "CDTV extended ROM v1.00",
-                "filename": "kick34005.CDTV"
-            },
-            {
-                "hash": "dc10d7bdd1b6f450773dfb558477c230",
-                "description": "Kickstart v2.04 rev 37.175",
-                "filename": "kick37175.A500"
-            },
-            {
-                "hash": "5f8924d013dd57a89cf349f4cdedc6b1",
-                "description": "CD32 Kickstart v3.1 rev 40.060",
-                "filename": "kick40060.CD32"
-            },
-            {
-                "hash": "f2f241bf094168cfb9e7805dc2856433",
-                "description": "CD32 KS + extended v3.1 rev 40.060",
-                "filename": "kick40060.CD32"
-            },
-            {
-                "hash": "bb72565701b1b6faece07d68ea5da639",
-                "description": "CD32 extended ROM rev 40.060",
-                "filename": "kick40060.CD32.ext"
-            },
-            {
-                "hash": "e40a5dfb3d017ba8779faba30cbd1c8e",
-                "description": "Kickstart v3.1 rev 40.063",
-                "filename": "kick40063.A600"
-            },
-            {
-                "hash": "646773759326fbac3b2311fd8c8793ee",
-                "description": "Kickstart v3.1 rev 40.068",
-                "filename": "kick40068.A1200"
-            },
-            {
-                "hash": "9bdedde6a4f33555b4a270c8ca53297d",
-                "description": "Kickstart v3.1 rev 40.068",
-                "filename": "kick40068.A4000"
+              "Core": "amiga",
+              "AlternateCoreName": "puae",
+              "Default": true
             }
-        ]
+          ]
+        }
+      ]
     },
-    {
-        "igdbId": 114,
-        "igdbName": "Amiga CD32",
-        "igdbSlug": "amiga-cd32",
-        "alternateNames": [
-            "Amiga CD32",
-            "Commodore Amiga CD32"
-        ],
-        "extensions": {
-            "supportedFileExtensions": [
-                ".ZIP"
-            ],
-            "uniqueFileExtensions": [
-            ]
-        },
-        "retroPieDirectoryName": "amiga",
-        "webEmulator": {
-            "type": "EmulatorJS",
-            "core": "amiga",
-            "availableWebEmulators": [
-                {
-                    "emulatorType": "EmulatorJS",
-                    "availableWebEmulatorCores": [
-                        {
-                            "core": "amiga",
-                            "alternateCoreName": "puae",
-                            "default": true
-                        }
-                    ]
-                }
-            ]
-        },
-        "bios": [
+    "Bios": [
+      {
+        "hash": "85ad74194e87c08904327de1a9443b7a",
+        "description": "Kickstart v1.2 rev 33.180",
+        "filename": "kick33180.A500"
+      },
+      {
+        "hash": "82a21c1890cae844b3df741f2762d48d",
+        "description": "Kickstart v1.3 rev 34.005",
+        "filename": "kick34005.A500"
+      },
+      {
+        "hash": "89da1838a24460e4b93f4f0c5d92d48d",
+        "description": "CDTV extended ROM v1.00",
+        "filename": "kick34005.CDTV"
+      },
+      {
+        "hash": "dc10d7bdd1b6f450773dfb558477c230",
+        "description": "Kickstart v2.04 rev 37.175",
+        "filename": "kick37175.A500"
+      },
+      {
+        "hash": "5f8924d013dd57a89cf349f4cdedc6b1",
+        "description": "CD32 Kickstart v3.1 rev 40.060",
+        "filename": "kick40060.CD32"
+      },
+      {
+        "hash": "f2f241bf094168cfb9e7805dc2856433",
+        "description": "CD32 KS + extended v3.1 rev 40.060",
+        "filename": "kick40060.CD32"
+      },
+      {
+        "hash": "bb72565701b1b6faece07d68ea5da639",
+        "description": "CD32 extended ROM rev 40.060",
+        "filename": "kick40060.CD32.ext"
+      },
+      {
+        "hash": "e40a5dfb3d017ba8779faba30cbd1c8e",
+        "description": "Kickstart v3.1 rev 40.063",
+        "filename": "kick40063.A600"
+      },
+      {
+        "hash": "646773759326fbac3b2311fd8c8793ee",
+        "description": "Kickstart v3.1 rev 40.068",
+        "filename": "kick40068.A1200"
+      },
+      {
+        "hash": "9bdedde6a4f33555b4a270c8ca53297d",
+        "description": "Kickstart v3.1 rev 40.068",
+        "filename": "kick40068.A4000"
+      }
+    ]
+  },
+  {
+    "IGDBId": 114,
+    "IGDBName": "Amiga CD32",
+    "IGDBSlug": "amiga-cd32",
+    "AlternateNames": [
+      "Amiga CD32",
+      "Commodore Amiga CD32"
+    ],
+    "Extensions": {
+      "SupportedFileExtensions": [
+        ".ZIP"
+      ],
+      "UniqueFileExtensions": []
+    },
+    "RetroPieDirectoryName": "amiga",
+    "WebEmulator": {
+      "Type": "EmulatorJS",
+      "Core": "amiga",
+      "AvailableWebEmulators": [
+        {
+          "EmulatorType": "EmulatorJS",
+          "AvailableWebEmulatorCores": [
             {
-                "hash": "85ad74194e87c08904327de1a9443b7a",
-                "description": "Kickstart v1.2 rev 33.180",
-                "filename": "kick33180.A500"
-            },
-            {
-                "hash": "82a21c1890cae844b3df741f2762d48d",
-                "description": "Kickstart v1.3 rev 34.005",
-                "filename": "kick34005.A500"
-            },
-            {
-                "hash": "89da1838a24460e4b93f4f0c5d92d48d",
-                "description": "CDTV extended ROM v1.00",
-                "filename": "kick34005.CDTV"
-            },
-            {
-                "hash": "dc10d7bdd1b6f450773dfb558477c230",
-                "description": "Kickstart v2.04 rev 37.175",
-                "filename": "kick37175.A500"
-            },
-            {
-                "hash": "5f8924d013dd57a89cf349f4cdedc6b1",
-                "description": "CD32 Kickstart v3.1 rev 40.060",
-                "filename": "kick40060.CD32"
-            },
-            {
-                "hash": "f2f241bf094168cfb9e7805dc2856433",
-                "description": "CD32 KS + extended v3.1 rev 40.060",
-                "filename": "kick40060.CD32"
-            },
-            {
-                "hash": "bb72565701b1b6faece07d68ea5da639",
-                "description": "CD32 extended ROM rev 40.060",
-                "filename": "kick40060.CD32.ext"
-            },
-            {
-                "hash": "e40a5dfb3d017ba8779faba30cbd1c8e",
-                "description": "Kickstart v3.1 rev 40.063",
-                "filename": "kick40063.A600"
-            },
-            {
-                "hash": "646773759326fbac3b2311fd8c8793ee",
-                "description": "Kickstart v3.1 rev 40.068",
-                "filename": "kick40068.A1200"
-            },
-            {
-                "hash": "9bdedde6a4f33555b4a270c8ca53297d",
-                "description": "Kickstart v3.1 rev 40.068",
-                "filename": "kick40068.A4000"
+              "Core": "amiga",
+              "AlternateCoreName": "puae",
+              "Default": true
             }
-        ]
+          ]
+        }
+      ]
     },
-    {
-        "igdbId": 25,
-        "igdbName": "Amstrad CPC",
-        "igdbSlug": "acpc",
-        "alternateNames": [
-            "acpc",
-            "Amstrad CPC",
-            "Colour Personal Computer"
-        ],
-        "extensions": {
-            "supportedFileExtensions": [
-                ".CPC",
-                ".DSK"
-            ],
-            "uniqueFileExtensions": [
-                ".CPC"
-            ]
-        },
-        "retroPieDirectoryName": "amstradcpc",
-        "webEmulator": {
-            "type": "",
-            "core": ""
-        },
-        "bios": []
+    "Bios": [
+      {
+        "hash": "85ad74194e87c08904327de1a9443b7a",
+        "description": "Kickstart v1.2 rev 33.180",
+        "filename": "kick33180.A500"
+      },
+      {
+        "hash": "82a21c1890cae844b3df741f2762d48d",
+        "description": "Kickstart v1.3 rev 34.005",
+        "filename": "kick34005.A500"
+      },
+      {
+        "hash": "89da1838a24460e4b93f4f0c5d92d48d",
+        "description": "CDTV extended ROM v1.00",
+        "filename": "kick34005.CDTV"
+      },
+      {
+        "hash": "dc10d7bdd1b6f450773dfb558477c230",
+        "description": "Kickstart v2.04 rev 37.175",
+        "filename": "kick37175.A500"
+      },
+      {
+        "hash": "5f8924d013dd57a89cf349f4cdedc6b1",
+        "description": "CD32 Kickstart v3.1 rev 40.060",
+        "filename": "kick40060.CD32"
+      },
+      {
+        "hash": "f2f241bf094168cfb9e7805dc2856433",
+        "description": "CD32 KS + extended v3.1 rev 40.060",
+        "filename": "kick40060.CD32"
+      },
+      {
+        "hash": "bb72565701b1b6faece07d68ea5da639",
+        "description": "CD32 extended ROM rev 40.060",
+        "filename": "kick40060.CD32.ext"
+      },
+      {
+        "hash": "e40a5dfb3d017ba8779faba30cbd1c8e",
+        "description": "Kickstart v3.1 rev 40.063",
+        "filename": "kick40063.A600"
+      },
+      {
+        "hash": "646773759326fbac3b2311fd8c8793ee",
+        "description": "Kickstart v3.1 rev 40.068",
+        "filename": "kick40068.A1200"
+      },
+      {
+        "hash": "9bdedde6a4f33555b4a270c8ca53297d",
+        "description": "Kickstart v3.1 rev 40.068",
+        "filename": "kick40068.A4000"
+      }
+    ]
+  },
+  {
+    "IGDBId": 25,
+    "IGDBName": "Amstrad CPC",
+    "IGDBSlug": "acpc",
+    "AlternateNames": [
+      "acpc",
+      "Amstrad CPC",
+      "Colour Personal Computer"
+    ],
+    "Extensions": {
+      "SupportedFileExtensions": [
+        ".CPC",
+        ".DSK"
+      ],
+      "UniqueFileExtensions": [
+        ".CPC"
+      ]
     },
-    {
-        "igdbId": 75,
-        "igdbName": "Apple II",
-        "igdbSlug": "appleii",
-        "alternateNames": [
-            "Apple ][",
-            "Apple 2",
-            "Apple II",
-            "appleii"
-        ],
-        "extensions": {
-            "supportedFileExtensions": [
-                ".DSK"
-            ],
-            "uniqueFileExtensions": []
-        },
-        "retroPieDirectoryName": "apple2",
-        "webEmulator": {
-            "type": "",
-            "core": ""
-        },
-        "bios": []
+    "RetroPieDirectoryName": "amstradcpc",
+    "WebEmulator": {
+      "Type": "",
+      "Core": "",
+      "AvailableWebEmulators": []
     },
-    {
-        "igdbId": 52,
-        "igdbName": "Arcade",
-        "igdbSlug": "arcade",
-        "alternateNames": [
-            "Arcade"
-        ],
-        "extensions": {
-            "supportedFileExtensions": [
-                ".ZIP"
-            ],
-            "uniqueFileExtensions": []
-        },
-        "retroPieDirectoryName": "",
-        "webEmulator": {
-            "type": "EmulatorJS",
-            "core": "arcade",
-            "availableWebEmulators": [
-                {
-                    "emulatorType": "EmulatorJS",
-                    "availableWebEmulatorCores": [
-                        {
-                            "core": "arcade",
-                            "alternateCoreName": "fbneo",
-                            "default": true
-                        },
-                        {
-                            "core": "fbalpha2012_cps1"
-                        },
-                        {
-                            "core": "fbalpha2012_cps2"
-                        },
-                        {
-                            "core": "mame"
-                        }
-                    ]
-                }
-            ]
-        },
-        "bios": []
+    "Bios": []
+  },
+  {
+    "IGDBId": 154,
+    "IGDBName": "Amstrad PCW",
+    "IGDBSlug": "amstrad-pcw",
+    "AlternateNames": [],
+    "Extensions": {
+      "SupportedFileExtensions": [],
+      "UniqueFileExtensions": []
     },
-    {
-        "igdbId": 59,
-        "igdbName": "Atari 2600",
-        "igdbSlug": "atari2600",
-        "alternateNames": [
-            "Atari 2600",
-            "Atari VCS",
-            "atari2600"
-        ],
-        "extensions": {
-            "supportedFileExtensions": [
-                ".7Z",
-                ".A26",
-                ".BIN",
-                ".GZ",
-                ".ROM",
-                ".ZIP"
-            ],
-            "uniqueFileExtensions": [
-                ".A26"
-            ]
-        },
-        "retroPieDirectoryName": "atari2600",
-        "webEmulator": {
-            "type": "EmulatorJS",
-            "core": "atari2600",
-            "availableWebEmulators": [
-                {
-                    "emulatorType": "EmulatorJS",
-                    "availableWebEmulatorCores": [
-                        {
-                            "core": "atari2600",
-                            "alternateCoreName": "stella2014",
-                            "default": true
-                        }
-                    ]
-                }
-            ]
-        },
-        "bios": []
+    "RetroPieDirectoryName": "",
+    "WebEmulator": {
+      "Type": "",
+      "Core": "",
+      "AvailableWebEmulators": null
     },
-    {
-        "igdbId": 66,
-        "igdbName": "Atari 5200",
-        "igdbSlug": "atari5200",
-        "alternateNames": [
-            "Atari 5200",
-            "Atari 5200 SuperSystem",
-            "atari5200"
-        ],
-        "extensions": {
-            "supportedFileExtensions": [
-                ".A52",
-                ".ATR",
-                ".ATR.GZ",
-                ".BAS",
-                ".BIN",
-                ".CAR",
-                ".DCM",
-                ".XEX",
-                ".XFD",
-                ".XFD.GZ"
-            ],
-            "uniqueFileExtensions": [
-                ".A52",
-                ".ATR",
-                ".ATR.GZ",
-                ".BAS",
-                ".CAR",
-                ".DCM",
-                ".XEX",
-                ".XFD",
-                ".XFD.GZ"
-            ]
-        },
-        "retroPieDirectoryName": "atari5200",
-        "webEmulator": {
-            "type": "EmulatorJS",
-            "core": "atari5200",
-            "availableWebEmulators": [
-                {
-                    "emulatorType": "EmulatorJS",
-                    "availableWebEmulatorCores": [
-                        {
-                            "core": "atari5200",
-                            "alternateCoreName": "a5200",
-                            "default": true
-                        }
-                    ]
-                }
-            ]
-        },
-        "bios": [
+    "Bios": []
+  },
+  {
+    "IGDBId": 34,
+    "IGDBName": "Android",
+    "IGDBSlug": "android",
+    "AlternateNames": [
+      "Infocusa3"
+    ],
+    "Extensions": {
+      "SupportedFileExtensions": [],
+      "UniqueFileExtensions": []
+    },
+    "RetroPieDirectoryName": "",
+    "WebEmulator": {
+      "Type": "",
+      "Core": "",
+      "AvailableWebEmulators": null
+    },
+    "Bios": []
+  },
+  {
+    "IGDBId": 75,
+    "IGDBName": "Apple II",
+    "IGDBSlug": "appleii",
+    "AlternateNames": [
+      "Apple 2",
+      "Apple II",
+      "Apple ][",
+      "appleii"
+    ],
+    "Extensions": {
+      "SupportedFileExtensions": [
+        ".DSK"
+      ],
+      "UniqueFileExtensions": []
+    },
+    "RetroPieDirectoryName": "apple2",
+    "WebEmulator": {
+      "Type": "",
+      "Core": "",
+      "AvailableWebEmulators": []
+    },
+    "Bios": []
+  },
+  {
+    "IGDBId": 115,
+    "IGDBName": "Apple IIGS",
+    "IGDBSlug": "apple-iigs",
+    "AlternateNames": [],
+    "Extensions": {
+      "SupportedFileExtensions": [],
+      "UniqueFileExtensions": []
+    },
+    "RetroPieDirectoryName": "",
+    "WebEmulator": {
+      "Type": "",
+      "Core": "",
+      "AvailableWebEmulators": null
+    },
+    "Bios": []
+  },
+  {
+    "IGDBId": 52,
+    "IGDBName": "Arcade",
+    "IGDBSlug": "arcade",
+    "AlternateNames": [
+      "Arcade"
+    ],
+    "Extensions": {
+      "SupportedFileExtensions": [
+        ".ZIP"
+      ],
+      "UniqueFileExtensions": []
+    },
+    "RetroPieDirectoryName": "",
+    "WebEmulator": {
+      "Type": "EmulatorJS",
+      "Core": "arcade",
+      "AvailableWebEmulators": [
+        {
+          "EmulatorType": "EmulatorJS",
+          "AvailableWebEmulatorCores": [
             {
-                "hash": "281f20ea4320404ec820fb7ec0693b38",
-                "description": "BIOS for the Atari 5200",
-                "filename": "5200.rom"
+              "Core": "arcade",
+              "AlternateCoreName": "fbneo",
+              "Default": true
+            },
+            {
+              "Core": "fbalpha2012_cps1",
+              "AlternateCoreName": "",
+              "Default": false
+            },
+            {
+              "Core": "fbalpha2012_cps2",
+              "AlternateCoreName": "",
+              "Default": false
+            },
+            {
+              "Core": "mame",
+              "AlternateCoreName": "",
+              "Default": false
             }
-        ]
+          ]
+        }
+      ]
     },
-    {
-        "igdbId": 60,
-        "igdbName": "Atari 7800",
-        "igdbSlug": "atari7800",
-        "alternateNames": [
-            "Atari 7800",
-            "Atari 7800 ProSystem",
-            "Atari VCS",
-            "atari7800"
-        ],
-        "extensions": {
-            "supportedFileExtensions": [
-                ".7Z",
-                ".A78",
-                ".BIN",
-                ".ZIP"
-            ],
-            "uniqueFileExtensions": [
-                ".A78"
-            ]
-        },
-        "retroPieDirectoryName": "atari7800",
-        "webEmulator": {
-            "type": "EmulatorJS",
-            "core": "atari7800",
-            "availableWebEmulators": [
-                {
-                    "emulatorType": "EmulatorJS",
-                    "availableWebEmulatorCores": [
-                        {
-                            "core": "atari7800",
-                            "alternateCoreName": "prosystem",
-                            "default": true
-                        }
-                    ]
-                }
-            ]
-        },
-        "bios": [
+    "Bios": []
+  },
+  {
+    "IGDBId": 59,
+    "IGDBName": "Atari 2600",
+    "IGDBSlug": "atari2600",
+    "AlternateNames": [
+      "Atari 2600",
+      "Atari VCS",
+      "atari2600"
+    ],
+    "Extensions": {
+      "SupportedFileExtensions": [
+        ".7Z",
+        ".A26",
+        ".BIN",
+        ".GZ",
+        ".ROM",
+        ".ZIP"
+      ],
+      "UniqueFileExtensions": [
+        ".A26"
+      ]
+    },
+    "RetroPieDirectoryName": "atari2600",
+    "WebEmulator": {
+      "Type": "EmulatorJS",
+      "Core": "atari2600",
+      "AvailableWebEmulators": [
+        {
+          "EmulatorType": "EmulatorJS",
+          "AvailableWebEmulatorCores": [
             {
-                "hash": "0763f1ffb006ddbe32e52d497ee848ae",
-                "description": "7800 BIOS - Optional",
-                "filename": "7800 BIOS (U).rom"
+              "Core": "atari2600",
+              "AlternateCoreName": "stella2014",
+              "Default": true
             }
-        ]
+          ]
+        }
+      ]
     },
-    {
-        "igdbId": 62,
-        "igdbName": "Atari Jaguar",
-        "igdbSlug": "jaguar",
-        "alternateNames": [
-            "Atari Jaguar",
-            "Jaguar"
-        ],
-        "extensions": {
-            "supportedFileExtensions": [
-                ".J64",
-                ".JAG"
-            ],
-            "uniqueFileExtensions": [
-                ".J64",
-                ".JAG"
-            ]
-        },
-        "retroPieDirectoryName": "atarijaguar",
-        "webEmulator": {
-            "type": "EmulatorJS",
-            "core": "jaguar",
-            "availableWebEmulators": [
-                {
-                    "emulatorType": "EmulatorJS",
-                    "availableWebEmulatorCores": [
-                        {
-                            "core": "jaguar",
-                            "alternateCoreName": "virtualjaguar",
-                            "default": true
-                        }
-                    ]
-                }
-            ]
-        },
-        "bios": []
+    "Bios": []
+  },
+  {
+    "IGDBId": 66,
+    "IGDBName": "Atari 5200",
+    "IGDBSlug": "atari5200",
+    "AlternateNames": [
+      "Atari 5200",
+      "Atari 5200 SuperSystem",
+      "atari5200"
+    ],
+    "Extensions": {
+      "SupportedFileExtensions": [
+        ".A52",
+        ".ATR",
+        ".ATR.GZ",
+        ".BAS",
+        ".BIN",
+        ".CAR",
+        ".DCM",
+        ".XEX",
+        ".XFD",
+        ".XFD.GZ"
+      ],
+      "UniqueFileExtensions": [
+        ".A52",
+        ".ATR",
+        ".ATR.GZ",
+        ".BAS",
+        ".CAR",
+        ".DCM",
+        ".XEX",
+        ".XFD",
+        ".XFD.GZ"
+      ]
     },
-    {
-        "igdbId": 61,
-        "igdbName": "Atari Lynx",
-        "igdbSlug": "lynx",
-        "alternateNames": [
-            "Atari Lynx",
-            "Lynx"
-        ],
-        "extensions": {
-            "supportedFileExtensions": [
-                ".7Z",
-                ".LNX",
-                ".ZIP"
-            ],
-            "uniqueFileExtensions": [
-                ".LNX"
-            ]
-        },
-        "retroPieDirectoryName": "atarilynx",
-        "webEmulator": {
-            "type": "EmulatorJS",
-            "core": "lynx",
-            "availableWebEmulators": [
-                {
-                    "emulatorType": "EmulatorJS",
-                    "availableWebEmulatorCores": [
-                        {
-                            "core": "lynx",
-                            "alternateCoreName": "handy",
-                            "default": true
-                        }
-                    ]
-                }
-            ]
-        },
-        "bios": [
+    "RetroPieDirectoryName": "atari5200",
+    "WebEmulator": {
+      "Type": "EmulatorJS",
+      "Core": "atari5200",
+      "AvailableWebEmulators": [
+        {
+          "EmulatorType": "EmulatorJS",
+          "AvailableWebEmulatorCores": [
             {
-                "hash": "fcd403db69f54290b51035d82f835e7b",
-                "description": "BIOS for the Atari Lynx",
-                "filename": "lynxboot.img"
+              "Core": "atari5200",
+              "AlternateCoreName": "a5200",
+              "Default": true
             }
-        ]
+          ]
+        }
+      ]
     },
-    {
-        "igdbId": 63,
-        "igdbName": "Atari ST/STE",
-        "igdbSlug": "atari-st",
-        "alternateNames": [
-            "Atari ST",
-            "Atari ST/STE",
-            "Atari STE",
-            "atari-st"
-        ],
-        "extensions": {
-            "supportedFileExtensions": [
-                ".CTR",
-                ".IMG",
-                ".IPF",
-                ".MSA",
-                ".RAW",
-                ".ROM",
-                ".ST",
-                ".STX",
-                ".ZIP"
-            ],
-            "uniqueFileExtensions": [
-                ".CTR",
-                ".MSA",
-                ".RAW",
-                ".ST",
-                ".STX"
-            ]
-        },
-        "retroPieDirectoryName": "atarist",
-        "webEmulator": {
-            "type": "",
-            "core": ""
-        },
-        "bios": [
+    "Bios": [
+      {
+        "hash": "281f20ea4320404ec820fb7ec0693b38",
+        "description": "BIOS for the Atari 5200",
+        "filename": "5200.rom"
+      }
+    ]
+  },
+  {
+    "IGDBId": 60,
+    "IGDBName": "Atari 7800",
+    "IGDBSlug": "atari7800",
+    "AlternateNames": [
+      "Atari 7800",
+      "Atari 7800 ProSystem",
+      "Atari VCS",
+      "atari7800"
+    ],
+    "Extensions": {
+      "SupportedFileExtensions": [
+        ".7Z",
+        ".A78",
+        ".BIN",
+        ".ZIP"
+      ],
+      "UniqueFileExtensions": [
+        ".A78"
+      ]
+    },
+    "RetroPieDirectoryName": "atari7800",
+    "WebEmulator": {
+      "Type": "EmulatorJS",
+      "Core": "atari7800",
+      "AvailableWebEmulators": [
+        {
+          "EmulatorType": "EmulatorJS",
+          "AvailableWebEmulatorCores": [
             {
-                "hash": "C1C57CE48E8EE4135885CEE9E63A68A2",
-                "description": "TOS",
-                "filename": "tos.img"
+              "Core": "atari7800",
+              "AlternateCoreName": "prosystem",
+              "Default": true
             }
-        ]
+          ]
+        }
+      ]
     },
-    {
-        "igdbId": 68,
-        "igdbName": "ColecoVision",
-        "igdbSlug": "colecovision",
-        "alternateNames": [
-            "ColecoVision"
-        ],
-        "extensions": {
-            "supportedFileExtensions": [
-                ".BIN",
-                ".COL",
-                ".ROM",
-                ".ZIP"
-            ],
-            "uniqueFileExtensions": [
-            ]
-        },
-        "retroPieDirectoryName": "coleco",
-        "webEmulator": {
-            "type": "EmulatorJS",
-            "core": "coleco",
-            "availableWebEmulators": [
-                {
-                    "emulatorType": "EmulatorJS",
-                    "availableWebEmulatorCores": [
-                        {
-                            "core": "coleco",
-                            "alternateCoreName": "coleco",
-                            "default": true
-                        }
-                    ]
-                }
-            ]
-        },
-        "bios": [
+    "Bios": [
+      {
+        "hash": "0763f1ffb006ddbe32e52d497ee848ae",
+        "description": "7800 BIOS - Optional",
+        "filename": "7800 BIOS (U).rom"
+      }
+    ]
+  },
+  {
+    "IGDBId": 65,
+    "IGDBName": "Atari 8-bit",
+    "IGDBSlug": "atari8bit",
+    "AlternateNames": [],
+    "Extensions": {
+      "SupportedFileExtensions": [],
+      "UniqueFileExtensions": []
+    },
+    "RetroPieDirectoryName": "",
+    "WebEmulator": {
+      "Type": "",
+      "Core": "",
+      "AvailableWebEmulators": null
+    },
+    "Bios": []
+  },
+  {
+    "IGDBId": 62,
+    "IGDBName": "Atari Jaguar",
+    "IGDBSlug": "jaguar",
+    "AlternateNames": [
+      "Atari Jaguar",
+      "Jaguar"
+    ],
+    "Extensions": {
+      "SupportedFileExtensions": [
+        ".J64",
+        ".JAG"
+      ],
+      "UniqueFileExtensions": [
+        ".J64",
+        ".JAG"
+      ]
+    },
+    "RetroPieDirectoryName": "atarijaguar",
+    "WebEmulator": {
+      "Type": "EmulatorJS",
+      "Core": "jaguar",
+      "AvailableWebEmulators": [
+        {
+          "EmulatorType": "EmulatorJS",
+          "AvailableWebEmulatorCores": [
             {
-                "hash": "2c66f5911e5b42b8ebe113403548eee7",
-                "description": "ColecoVision BIOS - Mandatory",
-                "filename": "colecovision.rom"
+              "Core": "jaguar",
+              "AlternateCoreName": "virtualjaguar",
+              "Default": true
             }
-        ]
+          ]
+        }
+      ]
     },
-    {
-        "igdbId": 15,
-        "igdbName": "Commodore C64/128/MAX",
-        "igdbSlug": "c64",
-        "alternateNames": [
-            "C64",
-            "C64/C128/MAX",
-            "Commodore C128",
-            "Commodore C64",
-            "Commodore C64/128/MAX",
-            "Commodore C64DTV"
-        ],
-        "extensions": {
-            "supportedFileExtensions": [
-                ".CRT",
-                ".D64",
-                ".D80",
-                ".D81",
-                ".G64",
-                ".M3U",
-                ".PRG",
-                ".T64",
-                ".TAP",
-                ".X64",
-                ".ZIP"
-            ],
-            "uniqueFileExtensions": [
-                ".CRT",
-                ".D64",
-                ".D80",
-                ".D81",
-                ".G64",
-                ".PRG",
-                ".T64",
-                ".X64"
-            ]
-        },
-        "retroPieDirectoryName": "c64",
-        "webEmulator": {
-            "type": "EmulatorJS",
-            "core": "vice_x64",
-            "availableWebEmulators": [
-                {
-                    "emulatorType": "EmulatorJS",
-                    "availableWebEmulatorCores": [
-                        {
-                            "core": "c64",
-                            "alternateCoreName": "vice_x64sc",
-                            "default": true
-                        },
-                        {
-                            "core": "vice_x64"
-                        }
-                    ]
-                }
-            ]
-        },
-        "bios": [
+    "Bios": []
+  },
+  {
+    "IGDBId": 410,
+    "IGDBName": "Atari Jaguar CD",
+    "IGDBSlug": "atari-jaguar-cd",
+    "AlternateNames": [
+      "Jag CD"
+    ],
+    "Extensions": {
+      "SupportedFileExtensions": [],
+      "UniqueFileExtensions": []
+    },
+    "RetroPieDirectoryName": "",
+    "WebEmulator": {
+      "Type": "",
+      "Core": "",
+      "AvailableWebEmulators": null
+    },
+    "Bios": []
+  },
+  {
+    "IGDBId": 61,
+    "IGDBName": "Atari Lynx",
+    "IGDBSlug": "lynx",
+    "AlternateNames": [
+      "Atari Lynx",
+      "Lynx"
+    ],
+    "Extensions": {
+      "SupportedFileExtensions": [
+        ".7Z",
+        ".LNX",
+        ".ZIP"
+      ],
+      "UniqueFileExtensions": [
+        ".LNX"
+      ]
+    },
+    "RetroPieDirectoryName": "atarilynx",
+    "WebEmulator": {
+      "Type": "EmulatorJS",
+      "Core": "lynx",
+      "AvailableWebEmulators": [
+        {
+          "EmulatorType": "EmulatorJS",
+          "AvailableWebEmulatorCores": [
             {
-                "hash": "1b1e985ea5325a1f46eb7fd9681707bf",
-                "description": "JiffyDOS 1541 drive BIOS",
-                "filename": "JiffyDOS_1541-II.bin"
-            },
-            {
-                "hash": "41c6cc528e9515ffd0ed9b180f8467c0",
-                "description": "JiffyDOS 1571 drive BIOS",
-                "filename": "JiffyDOS_1571_repl310654.bin"
-            },
-            {
-                "hash": "20b6885c6dc2d42c38754a365b043d71",
-                "description": "JiffyDOS 1581 drive BIOS",
-                "filename": "JiffyDOS_1581.bin"
-            },
-            {
-                "hash": "be09394f0576cf81fa8bacf634daf9a2",
-                "description": "JiffyDOS C64 Kernal",
-                "filename": "JiffyDOS_C64.bin"
+              "Core": "lynx",
+              "AlternateCoreName": "handy",
+              "Default": true
             }
-        ]
+          ]
+        }
+      ]
     },
-    {
-        "igdbId": 90,
-        "igdbName": "Commodore PET",
-        "igdbSlug": "cpet",
-        "alternateNames": [
-            "cpet",
-            "PET",
-            "Commodore PET"
-        ],
-        "extensions": {
-            "supportedFileExtensions": [
-                ".CRT",
-                ".D64",
-                ".D80",
-                ".D81",
-                ".G64",
-                ".M3U",
-                ".PRG",
-                ".T64",
-                ".TAP",
-                ".X64",
-                ".ZIP"
-            ],
-            "uniqueFileExtensions": [
-                ".CRT",
-                ".D64",
-                ".D80",
-                ".D81",
-                ".G64",
-                ".PRG",
-                ".T64",
-                ".X64"
-            ]
-        },
-        "retroPieDirectoryName": "c64",
-        "webEmulator": {
-            "type": "EmulatorJS",
-            "core": "vice_xpet",
-            "availableWebEmulators": [
-                {
-                    "emulatorType": "EmulatorJS",
-                    "availableWebEmulatorCores": [
-                        {
-                            "core": "pet",
-                            "alternateCoreName": "vice_xpet",
-                            "default": true
-                        }
-                    ]
-                }
-            ]
-        },
-        "bios": [
-        ]
+    "Bios": [
+      {
+        "hash": "fcd403db69f54290b51035d82f835e7b",
+        "description": "BIOS for the Atari Lynx",
+        "filename": "lynxboot.img"
+      }
+    ]
+  },
+  {
+    "IGDBId": 63,
+    "IGDBName": "Atari ST/STE",
+    "IGDBSlug": "atari-st",
+    "AlternateNames": [
+      "Atari ST",
+      "Atari ST/STE",
+      "Atari STE",
+      "atari-st"
+    ],
+    "Extensions": {
+      "SupportedFileExtensions": [
+        ".CTR",
+        ".IMG",
+        ".IPF",
+        ".MSA",
+        ".RAW",
+        ".ROM",
+        ".ST",
+        ".STX",
+        ".ZIP"
+      ],
+      "UniqueFileExtensions": [
+        ".CTR",
+        ".MSA",
+        ".RAW",
+        ".ST",
+        ".STX"
+      ]
     },
-    {
-        "igdbId": 94,
-        "igdbName": "Commodore Plus/4",
-        "igdbSlug": "c-plus-4",
-        "alternateNames": [
-            "C+4",
-            "c-plus-4",
-            "Plus/4",
-            "Commodore Plus/4"
-        ],
-        "extensions": {
-            "supportedFileExtensions": [
-                ".CRT",
-                ".D64",
-                ".D80",
-                ".D81",
-                ".G64",
-                ".M3U",
-                ".PRG",
-                ".T64",
-                ".TAP",
-                ".X64",
-                ".ZIP"
-            ],
-            "uniqueFileExtensions": [
-                ".CRT",
-                ".D64",
-                ".D80",
-                ".D81",
-                ".G64",
-                ".PRG",
-                ".T64",
-                ".X64"
-            ]
-        },
-        "retroPieDirectoryName": "c64",
-        "webEmulator": {
-            "type": "EmulatorJS",
-            "core": "vice_xplus4",
-            "availableWebEmulators": [
-                {
-                    "emulatorType": "EmulatorJS",
-                    "availableWebEmulatorCores": [
-                        {
-                            "core": "plus4",
-                            "alternateCoreName": "vice_xplus4",
-                            "default": true
-                        }
-                    ]
-                }
-            ]
-        },
-        "bios": [
-        ]
+    "RetroPieDirectoryName": "atarist",
+    "WebEmulator": {
+      "Type": "",
+      "Core": "",
+      "AvailableWebEmulators": []
     },
-    {
-        "igdbId": 71,
-        "igdbName": "Commodore VIC-20",
-        "igdbSlug": "vic-20",
-        "alternateNames": [
-            "VIC20",
-            "VIC-20",
-            "Commodore VIC-20"
-        ],
-        "extensions": {
-            "supportedFileExtensions": [
-                ".CRT",
-                ".D64",
-                ".D80",
-                ".D81",
-                ".G64",
-                ".M3U",
-                ".PRG",
-                ".T64",
-                ".TAP",
-                ".X64",
-                ".ZIP"
-            ],
-            "uniqueFileExtensions": [
-                ".CRT",
-                ".D64",
-                ".D80",
-                ".D81",
-                ".G64",
-                ".PRG",
-                ".T64",
-                ".X64"
-            ]
-        },
-        "retroPieDirectoryName": "c64",
-        "webEmulator": {
-            "type": "EmulatorJS",
-            "core": "vice_xvic",
-            "availableWebEmulators": [
-                {
-                    "emulatorType": "EmulatorJS",
-                    "availableWebEmulatorCores": [
-                        {
-                            "core": "vic20",
-                            "alternateCoreName": "vice_xvic",
-                            "default": true
-                        }
-                    ]
-                }
-            ]
-        },
-        "bios": [
-        ]
+    "Bios": [
+      {
+        "hash": "c1c57ce48e8ee4135885cee9e63a68a2",
+        "description": "TOS",
+        "filename": "tos.img"
+      }
+    ]
+  },
+  {
+    "IGDBId": 140,
+    "IGDBName": "AY-3-8500",
+    "IGDBSlug": "ay-3-8500",
+    "AlternateNames": [],
+    "Extensions": {
+      "SupportedFileExtensions": [],
+      "UniqueFileExtensions": []
     },
-    {
-        "igdbId": 158,
-        "igdbName": "Commodore CDTV",
-        "igdbSlug": "commodore-cdtv",
-        "alternateNames": [
-            "Commodore CDTV",
-            "Amiga CDTV",
-            "Commodore Amiga CDTV"
-        ],
-        "extensions": {
-            "supportedFileExtensions": [
-                ".ZIP"
-            ],
-            "uniqueFileExtensions": [
-            ]
-        },
-        "retroPieDirectoryName": "amiga",
-        "webEmulator": {
-            "type": "EmulatorJS",
-            "core": "amiga",
-            "availableWebEmulators": [
-                {
-                    "emulatorType": "EmulatorJS",
-                    "availableWebEmulatorCores": [
-                        {
-                            "core": "amiga",
-                            "alternateCoreName": "puae",
-                            "default": true
-                        }
-                    ]
-                }
-            ]
-        },
-        "bios": [
+    "RetroPieDirectoryName": "",
+    "WebEmulator": {
+      "Type": "",
+      "Core": "",
+      "AvailableWebEmulators": null
+    },
+    "Bios": []
+  },
+  {
+    "IGDBId": 141,
+    "IGDBName": "AY-3-8610",
+    "IGDBSlug": "ay-3-8610",
+    "AlternateNames": [],
+    "Extensions": {
+      "SupportedFileExtensions": [],
+      "UniqueFileExtensions": []
+    },
+    "RetroPieDirectoryName": "",
+    "WebEmulator": {
+      "Type": "",
+      "Core": "",
+      "AvailableWebEmulators": null
+    },
+    "Bios": []
+  },
+  {
+    "IGDBId": 91,
+    "IGDBName": "Bally Astrocade",
+    "IGDBSlug": "astrocade",
+    "AlternateNames": [
+      "Bally Arcade"
+    ],
+    "Extensions": {
+      "SupportedFileExtensions": [],
+      "UniqueFileExtensions": []
+    },
+    "RetroPieDirectoryName": "",
+    "WebEmulator": {
+      "Type": "",
+      "Core": "",
+      "AvailableWebEmulators": null
+    },
+    "Bios": []
+  },
+  {
+    "IGDBId": 69,
+    "IGDBName": "BBC Microcomputer System",
+    "IGDBSlug": "bbcmicro",
+    "AlternateNames": [
+      "BBC Micro"
+    ],
+    "Extensions": {
+      "SupportedFileExtensions": [],
+      "UniqueFileExtensions": []
+    },
+    "RetroPieDirectoryName": "",
+    "WebEmulator": {
+      "Type": "",
+      "Core": "",
+      "AvailableWebEmulators": null
+    },
+    "Bios": []
+  },
+  {
+    "IGDBId": 73,
+    "IGDBName": "BlackBerry OS",
+    "IGDBSlug": "blackberry",
+    "AlternateNames": [],
+    "Extensions": {
+      "SupportedFileExtensions": [],
+      "UniqueFileExtensions": []
+    },
+    "RetroPieDirectoryName": "",
+    "WebEmulator": {
+      "Type": "",
+      "Core": "",
+      "AvailableWebEmulators": null
+    },
+    "Bios": []
+  },
+  {
+    "IGDBId": 68,
+    "IGDBName": "ColecoVision",
+    "IGDBSlug": "colecovision",
+    "AlternateNames": [
+      "Coleco",
+      "ColecoVision"
+    ],
+    "Extensions": {
+      "SupportedFileExtensions": [
+        ".BIN",
+        ".COL",
+        ".ROM",
+        ".ZIP"
+      ],
+      "UniqueFileExtensions": [
+        ".COL"
+      ]
+    },
+    "RetroPieDirectoryName": "coleco",
+    "WebEmulator": {
+      "Type": "EmulatorJS",
+      "Core": "coleco",
+      "AvailableWebEmulators": [
+        {
+          "EmulatorType": "EmulatorJS",
+          "AvailableWebEmulatorCores": [
             {
-                "hash": "85ad74194e87c08904327de1a9443b7a",
-                "description": "Kickstart v1.2 rev 33.180",
-                "filename": "kick33180.A500"
-            },
-            {
-                "hash": "82a21c1890cae844b3df741f2762d48d",
-                "description": "Kickstart v1.3 rev 34.005",
-                "filename": "kick34005.A500"
-            },
-            {
-                "hash": "89da1838a24460e4b93f4f0c5d92d48d",
-                "description": "CDTV extended ROM v1.00",
-                "filename": "kick34005.CDTV"
-            },
-            {
-                "hash": "dc10d7bdd1b6f450773dfb558477c230",
-                "description": "Kickstart v2.04 rev 37.175",
-                "filename": "kick37175.A500"
-            },
-            {
-                "hash": "5f8924d013dd57a89cf349f4cdedc6b1",
-                "description": "CD32 Kickstart v3.1 rev 40.060",
-                "filename": "kick40060.CD32"
-            },
-            {
-                "hash": "f2f241bf094168cfb9e7805dc2856433",
-                "description": "CD32 KS + extended v3.1 rev 40.060",
-                "filename": "kick40060.CD32"
-            },
-            {
-                "hash": "bb72565701b1b6faece07d68ea5da639",
-                "description": "CD32 extended ROM rev 40.060",
-                "filename": "kick40060.CD32.ext"
-            },
-            {
-                "hash": "e40a5dfb3d017ba8779faba30cbd1c8e",
-                "description": "Kickstart v3.1 rev 40.063",
-                "filename": "kick40063.A600"
-            },
-            {
-                "hash": "646773759326fbac3b2311fd8c8793ee",
-                "description": "Kickstart v3.1 rev 40.068",
-                "filename": "kick40068.A1200"
-            },
-            {
-                "hash": "9bdedde6a4f33555b4a270c8ca53297d",
-                "description": "Kickstart v3.1 rev 40.068",
-                "filename": "kick40068.A4000"
+              "Core": "coleco",
+              "AlternateCoreName": "coleco",
+              "Default": true
             }
-        ]
+          ]
+        }
+      ]
     },
-    {
-        "igdbId": 33,
-        "igdbName": "Game Boy",
-        "igdbSlug": "gb",
-        "alternateNames": [
-            "Game Boy",
-            "GB"
-        ],
-        "extensions": {
-            "supportedFileExtensions": [
-                ".7Z",
-                ".GB",
-                ".ZIP"
-            ],
-            "uniqueFileExtensions": [
-                ".GB"
-            ]
-        },
-        "retroPieDirectoryName": "gb",
-        "webEmulator": {
-            "type": "EmulatorJS",
-            "core": "gb",
-            "availableWebEmulators": [
-                {
-                    "emulatorType": "EmulatorJS",
-                    "availableWebEmulatorCores": [
-                        {
-                            "core": "gb",
-                            "alternateCoreName": "gambatte",
-                            "default": true
-                        },
-                        {
-                            "core": "mgba"
-                        }
-                    ]
-                }
-            ]
-        },
-        "bios": [
+    "Bios": [
+      {
+        "hash": "2c66f5911e5b42b8ebe113403548eee7",
+        "description": "ColecoVision BIOS - Mandatory",
+        "filename": "colecovision.rom"
+      }
+    ]
+  },
+  {
+    "IGDBId": 93,
+    "IGDBName": "Commodore 16",
+    "IGDBSlug": "c16",
+    "AlternateNames": [
+      "C16"
+    ],
+    "Extensions": {
+      "SupportedFileExtensions": [],
+      "UniqueFileExtensions": []
+    },
+    "RetroPieDirectoryName": "",
+    "WebEmulator": {
+      "Type": "",
+      "Core": "",
+      "AvailableWebEmulators": null
+    },
+    "Bios": []
+  },
+  {
+    "IGDBId": 15,
+    "IGDBName": "Commodore C64/128/MAX",
+    "IGDBSlug": "c64",
+    "AlternateNames": [
+      "C64",
+      "C64/C128/MAX",
+      "Commodore C128",
+      "Commodore C64",
+      "Commodore C64/128/MAX",
+      "Commodore C64DTV"
+    ],
+    "Extensions": {
+      "SupportedFileExtensions": [
+        ".CRT",
+        ".D64",
+        ".D80",
+        ".D81",
+        ".G64",
+        ".M3U",
+        ".PRG",
+        ".T64",
+        ".TAP",
+        ".X64",
+        ".ZIP"
+      ],
+      "UniqueFileExtensions": []
+    },
+    "RetroPieDirectoryName": "c64",
+    "WebEmulator": {
+      "Type": "EmulatorJS",
+      "Core": "vice_x64",
+      "AvailableWebEmulators": [
+        {
+          "EmulatorType": "EmulatorJS",
+          "AvailableWebEmulatorCores": [
             {
-                "hash": "32fbbd84168d3482956eb3c5051637f5",
-                "description": "BIOS for Game Boy",
-                "filename": "gb_bios.bin"
+              "Core": "c64",
+              "AlternateCoreName": "vice_x64sc",
+              "Default": true
             },
             {
-                "hash": "d574d4f9c12f305074798f54c091a8b4",
-                "description": "Super Game Boy",
-                "filename": "sgb_bios.bin"
+              "Core": "vice_x64",
+              "AlternateCoreName": "",
+              "Default": false
             }
-        ]
+          ]
+        }
+      ]
     },
-    {
-        "igdbId": 24,
-        "igdbName": "Game Boy Advance",
-        "igdbSlug": "gba",
-        "alternateNames": [
-            "Game Boy Advance",
-            "GBA"
-        ],
-        "extensions": {
-            "supportedFileExtensions": [
-                ".7Z",
-                ".GBA",
-                ".ZIP"
-            ],
-            "uniqueFileExtensions": [
-                ".GBA"
-            ]
-        },
-        "retroPieDirectoryName": "gba",
-        "webEmulator": {
-            "type": "EmulatorJS",
-            "core": "gba",
-            "availableWebEmulators": [
-                {
-                    "emulatorType": "EmulatorJS",
-                    "availableWebEmulatorCores": [
-                        {
-                            "core": "gb",
-                            "alternateCoreName": "mgba",
-                            "default": true
-                        }
-                    ]
-                }
-            ]
-        },
-        "bios": [
+    "Bios": [
+      {
+        "hash": "1b1e985ea5325a1f46eb7fd9681707bf",
+        "description": "JiffyDOS 1541 drive BIOS",
+        "filename": "JiffyDOS_1541-II.bin"
+      },
+      {
+        "hash": "41c6cc528e9515ffd0ed9b180f8467c0",
+        "description": "JiffyDOS 1571 drive BIOS",
+        "filename": "JiffyDOS_1571_repl310654.bin"
+      },
+      {
+        "hash": "20b6885c6dc2d42c38754a365b043d71",
+        "description": "JiffyDOS 1581 drive BIOS",
+        "filename": "JiffyDOS_1581.bin"
+      },
+      {
+        "hash": "be09394f0576cf81fa8bacf634daf9a2",
+        "description": "JiffyDOS C64 Kernal",
+        "filename": "JiffyDOS_C64.bin"
+      }
+    ]
+  },
+  {
+    "IGDBId": 158,
+    "IGDBName": "Commodore CDTV",
+    "IGDBSlug": "commodore-cdtv",
+    "AlternateNames": [
+      "Amiga CDTV",
+      "Commodore Amiga CDTV",
+      "Commodore CDTV",
+      "Commodore Dynamic Total Vision"
+    ],
+    "Extensions": {
+      "SupportedFileExtensions": [
+        ".ZIP"
+      ],
+      "UniqueFileExtensions": []
+    },
+    "RetroPieDirectoryName": "amiga",
+    "WebEmulator": {
+      "Type": "EmulatorJS",
+      "Core": "amiga",
+      "AvailableWebEmulators": [
+        {
+          "EmulatorType": "EmulatorJS",
+          "AvailableWebEmulatorCores": [
             {
-                "hash": "32FBBD84168D3482956EB3C5051637F5",
-                "description": "[BIOS] Nintendo Game Boy Boot ROM (World) (Rev 1).gb",
-                "filename": "gb_bios.bin"
-            },
-            {
-                "hash": "a860e8c0b6d573d191e4ec7db1b1e4f6",
-                "description": "[BIOS] Game Boy Advance (World).gba",
-                "filename": "gba_bios.bin"
-            },
-            {
-                "hash": "DBFCE9DB9DEAA2567F6A84FDE55F9680",
-                "description": "[BIOS] Nintendo Game Boy Color Boot ROM (World).gbc",
-                "filename": "gbc_bios.bin"
-            },
-            {
-                "hash": "D574D4F9C12F305074798F54C091A8B4",
-                "description": "SGB-CPU (World) (Enhancement Chip).bin",
-                "filename": "sgb_bios.bin"
+              "Core": "amiga",
+              "AlternateCoreName": "puae",
+              "Default": true
             }
-        ]
+          ]
+        }
+      ]
     },
-    {
-        "igdbId": 22,
-        "igdbName": "Game Boy Color",
-        "igdbSlug": "gbc",
-        "alternateNames": [
-            "Game Boy Color",
-            "GBC"
-        ],
-        "extensions": {
-            "supportedFileExtensions": [
-                ".7Z",
-                ".GBC",
-                ".ZIP"
-            ],
-            "uniqueFileExtensions": [
-                ".GBC"
-            ]
-        },
-        "retroPieDirectoryName": "gbc",
-        "webEmulator": {
-            "type": "EmulatorJS",
-            "core": "gb",
-            "availableWebEmulators": [
-                {
-                    "emulatorType": "EmulatorJS",
-                    "availableWebEmulatorCores": [
-                        {
-                            "core": "gb",
-                            "alternateCoreName": "gambatte",
-                            "default": true
-                        },
-                        {
-                            "core": "mgba"
-                        }
-                    ]
-                }
-            ]
-        },
-        "bios": [
+    "Bios": [
+      {
+        "hash": "85ad74194e87c08904327de1a9443b7a",
+        "description": "Kickstart v1.2 rev 33.180",
+        "filename": "kick33180.A500"
+      },
+      {
+        "hash": "82a21c1890cae844b3df741f2762d48d",
+        "description": "Kickstart v1.3 rev 34.005",
+        "filename": "kick34005.A500"
+      },
+      {
+        "hash": "89da1838a24460e4b93f4f0c5d92d48d",
+        "description": "CDTV extended ROM v1.00",
+        "filename": "kick34005.CDTV"
+      },
+      {
+        "hash": "dc10d7bdd1b6f450773dfb558477c230",
+        "description": "Kickstart v2.04 rev 37.175",
+        "filename": "kick37175.A500"
+      },
+      {
+        "hash": "5f8924d013dd57a89cf349f4cdedc6b1",
+        "description": "CD32 Kickstart v3.1 rev 40.060",
+        "filename": "kick40060.CD32"
+      },
+      {
+        "hash": "f2f241bf094168cfb9e7805dc2856433",
+        "description": "CD32 KS + extended v3.1 rev 40.060",
+        "filename": "kick40060.CD32"
+      },
+      {
+        "hash": "bb72565701b1b6faece07d68ea5da639",
+        "description": "CD32 extended ROM rev 40.060",
+        "filename": "kick40060.CD32.ext"
+      },
+      {
+        "hash": "e40a5dfb3d017ba8779faba30cbd1c8e",
+        "description": "Kickstart v3.1 rev 40.063",
+        "filename": "kick40063.A600"
+      },
+      {
+        "hash": "646773759326fbac3b2311fd8c8793ee",
+        "description": "Kickstart v3.1 rev 40.068",
+        "filename": "kick40068.A1200"
+      },
+      {
+        "hash": "9bdedde6a4f33555b4a270c8ca53297d",
+        "description": "Kickstart v3.1 rev 40.068",
+        "filename": "kick40068.A4000"
+      }
+    ]
+  },
+  {
+    "IGDBId": 90,
+    "IGDBName": "Commodore PET",
+    "IGDBSlug": "cpet",
+    "AlternateNames": [
+      "Commodore PET",
+      "cpet",
+      "PET"
+    ],
+    "Extensions": {
+      "SupportedFileExtensions": [
+        ".CRT",
+        ".D64",
+        ".D80",
+        ".D81",
+        ".G64",
+        ".M3U",
+        ".PRG",
+        ".T64",
+        ".TAP",
+        ".X64",
+        ".ZIP"
+      ],
+      "UniqueFileExtensions": []
+    },
+    "RetroPieDirectoryName": "c64",
+    "WebEmulator": {
+      "Type": "EmulatorJS",
+      "Core": "vice_xpet",
+      "AvailableWebEmulators": [
+        {
+          "EmulatorType": "EmulatorJS",
+          "AvailableWebEmulatorCores": [
             {
-                "hash": "dbfce9db9deaa2567f6a84fde55f9680",
-                "description": "BIOS for Game Boy Color",
-                "filename": "gbc_bios.bin"
-            },
-            {
-                "hash": "d574d4f9c12f305074798f54c091a8b4",
-                "description": "Super Game Boy",
-                "filename": "sgb_bios.bin"
+              "Core": "pet",
+              "AlternateCoreName": "vice_xpet",
+              "Default": true
             }
-        ]
+          ]
+        }
+      ]
     },
-    {
-        "igdbId": 4,
-        "igdbName": "Nintendo 64",
-        "igdbSlug": "n64",
-        "alternateNames": [
-            "N64",
-            "Nintendo 64"
-        ],
-        "extensions": {
-            "supportedFileExtensions": [
-                ".N64",
-                ".V64",
-                ".Z64",
-                ".ZIP"
-            ],
-            "uniqueFileExtensions": [
-                ".N64",
-                ".V64",
-                ".Z64"
-            ]
-        },
-        "retroPieDirectoryName": "n64",
-        "webEmulator": {
-            "type": "EmulatorJS",
-            "core": "n64",
-            "availableWebEmulators": [
-                {
-                    "emulatorType": "EmulatorJS",
-                    "availableWebEmulatorCores": [
-                        {
-                            "core": "n64",
-                            "alternateCoreName": "mupen64plus_next",
-                            "default": true
-                        }
-                    ]
-                }
-            ]
-        },
-        "bios": []
+    "Bios": []
+  },
+  {
+    "IGDBId": 94,
+    "IGDBName": "Commodore Plus/4",
+    "IGDBSlug": "c-plus-4",
+    "AlternateNames": [
+      "C+4",
+      "c-plus-4",
+      "Commodore Plus/4",
+      "Plus/4"
+    ],
+    "Extensions": {
+      "SupportedFileExtensions": [
+        ".CRT",
+        ".D64",
+        ".D80",
+        ".D81",
+        ".G64",
+        ".M3U",
+        ".PRG",
+        ".T64",
+        ".TAP",
+        ".X64",
+        ".ZIP"
+      ],
+      "UniqueFileExtensions": []
     },
-    {
-        "igdbId": 20,
-        "igdbName": "Nintendo DS",
-        "igdbSlug": "nds",
-        "alternateNames": [
-            "NDS"
-        ],
-        "extensions": {
-            "supportedFileExtensions": [
-                ".BIN",
-                ".NDS",
-                ".ZIP"
-            ],
-            "uniqueFileExtensions": [
-                ".NDS"
-            ]
-        },
-        "retroPieDirectoryName": "nds",
-        "webEmulator": {
-            "type": "EmulatorJS",
-            "core": "nds",
-            "availableWebEmulators": [
-                {
-                    "emulatorType": "EmulatorJS",
-                    "availableWebEmulatorCores": [
-                        {
-                            "core": "nds",
-                            "alternateCoreName": "melonds",
-                            "default": true
-                        },
-                        {
-                            "core": "desmume2015"
-                        }
-                    ]
-                }
-            ]
-        },
-        "bios": [
+    "RetroPieDirectoryName": "c64",
+    "WebEmulator": {
+      "Type": "EmulatorJS",
+      "Core": "vice_xplus4",
+      "AvailableWebEmulators": [
+        {
+          "EmulatorType": "EmulatorJS",
+          "AvailableWebEmulatorCores": [
             {
-                "hash": "df692a80a5b1bc90728bc3dfc76cd948",
-                "description": "ARM7 BIOS",
-                "filename": "bios7.bin"
-            },
-            {
-                "hash": "a392174eb3e572fed6447e956bde4b25",
-                "description": "ARM9 BIOS",
-                "filename": "bios9.bin"
-            },
-            {
-                "hash": "145eaef5bd3037cbc247c213bb3da1b3",
-                "description": "NDS Firmware",
-                "filename": "firmware.bin"
+              "Core": "plus4",
+              "AlternateCoreName": "vice_xplus4",
+              "Default": true
             }
-        ]
+          ]
+        }
+      ]
     },
-    {
-        "igdbId": 18,
-        "igdbName": "Nintendo Entertainment System",
-        "igdbSlug": "nes",
-        "alternateNames": [
-            "NES",
-            "Nintendo Entertainment System",
-            "Nintendo Famicom & Entertainment System"
-        ],
-        "extensions": {
-            "supportedFileExtensions": [
-                ".7Z",
-                ".FDS",
-                ".NES",
-                ".NEZ",
-                ".UNF",
-                ".UNIF",
-                ".ZIP"
-            ],
-            "uniqueFileExtensions": [
-                ".FDS",
-                ".NES",
-                ".NEZ",
-                ".UNF",
-                ".UNIF"
-            ]
-        },
-        "retroPieDirectoryName": "nes",
-        "webEmulator": {
-            "type": "EmulatorJS",
-            "core": "nes",
-            "availableWebEmulators": [
-                {
-                    "emulatorType": "EmulatorJS",
-                    "availableWebEmulatorCores": [
-                        {
-                            "core": "nes",
-                            "alternateCoreName": "fceumm",
-                            "default": true
-                        },
-                        {
-                            "core": "nestopia"
-                        }
-                    ]
-                }
-            ]
-        },
-        "bios": [
+    "Bios": []
+  },
+  {
+    "IGDBId": 71,
+    "IGDBName": "Commodore VIC-20",
+    "IGDBSlug": "vic-20",
+    "AlternateNames": [
+      "Commodore VIC-20",
+      "VIC-20",
+      "VIC20"
+    ],
+    "Extensions": {
+      "SupportedFileExtensions": [
+        ".CRT",
+        ".D64",
+        ".D80",
+        ".D81",
+        ".G64",
+        ".M3U",
+        ".PRG",
+        ".T64",
+        ".TAP",
+        ".X64",
+        ".ZIP"
+      ],
+      "UniqueFileExtensions": []
+    },
+    "RetroPieDirectoryName": "c64",
+    "WebEmulator": {
+      "Type": "EmulatorJS",
+      "Core": "vice_xvic",
+      "AvailableWebEmulators": [
+        {
+          "EmulatorType": "EmulatorJS",
+          "AvailableWebEmulatorCores": [
             {
-                "hash": "ca30b50f880eb660a320674ed365ef7a",
-                "description": "Family Computer Disk System BIOS - Required for Famicom Disk System emulation",
-                "filename": "disksys.rom"
+              "Core": "vic20",
+              "AlternateCoreName": "vice_xvic",
+              "Default": true
+            }
+          ]
+        }
+      ]
+    },
+    "Bios": []
+  },
+  {
+    "IGDBId": 13,
+    "IGDBName": "DOS",
+    "IGDBSlug": "dos",
+    "AlternateNames": [
+      "PC DOS"
+    ],
+    "Extensions": {
+      "SupportedFileExtensions": [],
+      "UniqueFileExtensions": []
+    },
+    "RetroPieDirectoryName": "",
+    "WebEmulator": {
+      "Type": "",
+      "Core": "",
+      "AvailableWebEmulators": null
+    },
+    "Bios": []
+  },
+  {
+    "IGDBId": 153,
+    "IGDBName": "Dragon 32/64",
+    "IGDBSlug": "dragon-32-slash-64",
+    "AlternateNames": [],
+    "Extensions": {
+      "SupportedFileExtensions": [],
+      "UniqueFileExtensions": []
+    },
+    "RetroPieDirectoryName": "",
+    "WebEmulator": {
+      "Type": "",
+      "Core": "",
+      "AvailableWebEmulators": null
+    },
+    "Bios": []
+  },
+  {
+    "IGDBId": 23,
+    "IGDBName": "Dreamcast",
+    "IGDBSlug": "dc",
+    "AlternateNames": [
+      "DC"
+    ],
+    "Extensions": {
+      "SupportedFileExtensions": [],
+      "UniqueFileExtensions": []
+    },
+    "RetroPieDirectoryName": "",
+    "WebEmulator": {
+      "Type": "",
+      "Core": "",
+      "AvailableWebEmulators": null
+    },
+    "Bios": []
+  },
+  {
+    "IGDBId": 203,
+    "IGDBName": "DUPLICATE Stadia",
+    "IGDBSlug": "duplicate-stadia",
+    "AlternateNames": [],
+    "Extensions": {
+      "SupportedFileExtensions": [],
+      "UniqueFileExtensions": []
+    },
+    "RetroPieDirectoryName": "",
+    "WebEmulator": {
+      "Type": "",
+      "Core": "",
+      "AvailableWebEmulators": null
+    },
+    "Bios": []
+  },
+  {
+    "IGDBId": 375,
+    "IGDBName": "Epoch Cassette Vision",
+    "IGDBSlug": "epoch-cassette-vision",
+    "AlternateNames": [],
+    "Extensions": {
+      "SupportedFileExtensions": [],
+      "UniqueFileExtensions": []
+    },
+    "RetroPieDirectoryName": "",
+    "WebEmulator": {
+      "Type": "",
+      "Core": "",
+      "AvailableWebEmulators": null
+    },
+    "Bios": []
+  },
+  {
+    "IGDBId": 376,
+    "IGDBName": "Epoch Super Cassette Vision",
+    "IGDBSlug": "epoch-super-cassette-vision",
+    "AlternateNames": [
+      "YENO Super Cassette Vision"
+    ],
+    "Extensions": {
+      "SupportedFileExtensions": [],
+      "UniqueFileExtensions": []
+    },
+    "RetroPieDirectoryName": "",
+    "WebEmulator": {
+      "Type": "",
+      "Core": "",
+      "AvailableWebEmulators": null
+    },
+    "Bios": []
+  },
+  {
+    "IGDBId": 309,
+    "IGDBName": "Evercade",
+    "IGDBSlug": "evercade",
+    "AlternateNames": [],
+    "Extensions": {
+      "SupportedFileExtensions": [],
+      "UniqueFileExtensions": []
+    },
+    "RetroPieDirectoryName": "",
+    "WebEmulator": {
+      "Type": "",
+      "Core": "",
+      "AvailableWebEmulators": null
+    },
+    "Bios": []
+  },
+  {
+    "IGDBId": 99,
+    "IGDBName": "Family Computer",
+    "IGDBSlug": "famicom",
+    "AlternateNames": [
+      "Famicom"
+    ],
+    "Extensions": {
+      "SupportedFileExtensions": [],
+      "UniqueFileExtensions": []
+    },
+    "RetroPieDirectoryName": "",
+    "WebEmulator": {
+      "Type": "EmulatorJS",
+      "Core": "nes",
+      "AvailableWebEmulators": [
+        {
+          "EmulatorType": "EmulatorJS",
+          "AvailableWebEmulatorCores": [
+            {
+              "Core": "nes",
+              "AlternateCoreName": "fceumm",
+              "Default": true
             },
             {
-                "hash": "7f98d77d7a094ad7d069b74bd553ec98",
-                "description": "Game Genie add-on cartridge - Required for Game Genei Add-on emulation (Only supported on the fceumm core)",
-                "filename": "gamegenie.nes"
+              "Core": "nestopia",
+              "AlternateCoreName": "",
+              "Default": false
             }
-        ]
+          ]
+        }
+      ]
     },
-    {
-        "igdbId": 21,
-        "igdbName": "Nintendo GameCube",
-        "igdbSlug": "ngc",
-        "alternateNames": [
-            "GameCube",
-            "GC",
-            "GCN",
-            "ngc",
-            "Nintendo GameCube"
-        ],
-        "extensions": {
-            "supportedFileExtensions": [
-                ".CISO",
-                ".GC",
-                ".GCM",
-                ".GCZ",
-                ".ISO",
-                ".RVZ"
-            ],
-            "uniqueFileExtensions": [
-                ".CISO",
-                ".GC",
-                ".GCM",
-                ".GCZ",
-                ".RVZ"
-            ]
-        },
-        "retroPieDirectoryName": "gc",
-        "webEmulator": {
-            "type": "",
-            "core": ""
-        },
-        "bios": []
+    "Bios": []
+  },
+  {
+    "IGDBId": 51,
+    "IGDBName": "Family Computer Disk System",
+    "IGDBSlug": "fds",
+    "AlternateNames": [
+      "Famicom Disk System, FDS"
+    ],
+    "Extensions": {
+      "SupportedFileExtensions": [],
+      "UniqueFileExtensions": []
     },
-    {
-        "igdbId": 7,
-        "igdbName": "PlayStation",
-        "igdbSlug": "ps",
-        "alternateNames": [
-            "PlayStation",
-            "PS",
-            "PS1",
-            "PSOne",
-            "PSX",
-            "PSX, PSOne, PS",
-            "Sony PlayStation"
-        ],
-        "extensions": {
-            "supportedFileExtensions": [
-                ".CCD",
-                ".CHD",
-                ".CUE",
-                ".EXE",
-                ".ISO",
-                ".M3U",
-                ".PBP",
-                ".TOC"
-            ],
-            "uniqueFileExtensions": [
-                ".CCD",
-                ".EXE",
-                ".PBP",
-                ".TOC"
-            ]
-        },
-        "retroPieDirectoryName": "psx",
-        "webEmulator": {
-            "type": "EmulatorJS",
-            "core": "psx",
-            "availableWebEmulators": [
-                {
-                    "emulatorType": "EmulatorJS",
-                    "availableWebEmulatorCores": [
-                        {
-                            "core": "psx",
-                            "alternateCoreName": "pcsx_rearmed",
-                            "default": true
-                        },
-                        {
-                            "core": "mednafen_psx"
-                        }
-                    ]
-                }
-            ]
-        },
-        "bios": [
+    "RetroPieDirectoryName": "",
+    "WebEmulator": {
+      "Type": "",
+      "Core": "",
+      "AvailableWebEmulators": null
+    },
+    "Bios": []
+  },
+  {
+    "IGDBId": 118,
+    "IGDBName": "FM Towns",
+    "IGDBSlug": "fm-towns",
+    "AlternateNames": [],
+    "Extensions": {
+      "SupportedFileExtensions": [],
+      "UniqueFileExtensions": []
+    },
+    "RetroPieDirectoryName": "",
+    "WebEmulator": {
+      "Type": "",
+      "Core": "",
+      "AvailableWebEmulators": null
+    },
+    "Bios": []
+  },
+  {
+    "IGDBId": 152,
+    "IGDBName": "FM-7",
+    "IGDBSlug": "fm-7",
+    "AlternateNames": [
+      "Fujitsu Micro 7"
+    ],
+    "Extensions": {
+      "SupportedFileExtensions": [],
+      "UniqueFileExtensions": []
+    },
+    "RetroPieDirectoryName": "",
+    "WebEmulator": {
+      "Type": "",
+      "Core": "",
+      "AvailableWebEmulators": null
+    },
+    "Bios": []
+  },
+  {
+    "IGDBId": 307,
+    "IGDBName": "Game & Watch",
+    "IGDBSlug": "game-and-watch",
+    "AlternateNames": [
+      "Tricotronic, GW, G&W"
+    ],
+    "Extensions": {
+      "SupportedFileExtensions": [],
+      "UniqueFileExtensions": []
+    },
+    "RetroPieDirectoryName": "",
+    "WebEmulator": {
+      "Type": "",
+      "Core": "",
+      "AvailableWebEmulators": null
+    },
+    "Bios": []
+  },
+  {
+    "IGDBId": 33,
+    "IGDBName": "Game Boy",
+    "IGDBSlug": "gb",
+    "AlternateNames": [
+      "Game Boy",
+      "GB"
+    ],
+    "Extensions": {
+      "SupportedFileExtensions": [
+        ".7Z",
+        ".GB",
+        ".ZIP"
+      ],
+      "UniqueFileExtensions": [
+        ".GB"
+      ]
+    },
+    "RetroPieDirectoryName": "gb",
+    "WebEmulator": {
+      "Type": "EmulatorJS",
+      "Core": "gb",
+      "AvailableWebEmulators": [
+        {
+          "EmulatorType": "EmulatorJS",
+          "AvailableWebEmulatorCores": [
             {
-                "hash": "8dd7d5296a650fac7319bce665a6a53c",
-                "description": "PS1 JP BIOS - Required for JP games",
-                "filename": "scph5500.bin"
+              "Core": "gb",
+              "AlternateCoreName": "gambatte",
+              "Default": true
             },
             {
-                "hash": "490f666e1afb15b7362b406ed1cea246",
-                "description": "PS1 US BIOS - Required for US games",
-                "filename": "scph5501.bin"
+              "Core": "mgba",
+              "AlternateCoreName": "",
+              "Default": false
+            }
+          ]
+        }
+      ]
+    },
+    "Bios": [
+      {
+        "hash": "32fbbd84168d3482956eb3c5051637f5",
+        "description": "BIOS for Game Boy",
+        "filename": "gb_bios.bin"
+      },
+      {
+        "hash": "d574d4f9c12f305074798f54c091a8b4",
+        "description": "Super Game Boy",
+        "filename": "sgb_bios.bin"
+      }
+    ]
+  },
+  {
+    "IGDBId": 24,
+    "IGDBName": "Game Boy Advance",
+    "IGDBSlug": "gba",
+    "AlternateNames": [
+      "Game Boy Advance",
+      "GBA"
+    ],
+    "Extensions": {
+      "SupportedFileExtensions": [
+        ".7Z",
+        ".GBA",
+        ".ZIP"
+      ],
+      "UniqueFileExtensions": [
+        ".GBA"
+      ]
+    },
+    "RetroPieDirectoryName": "gba",
+    "WebEmulator": {
+      "Type": "EmulatorJS",
+      "Core": "gba",
+      "AvailableWebEmulators": [
+        {
+          "EmulatorType": "EmulatorJS",
+          "AvailableWebEmulatorCores": [
+            {
+              "Core": "gb",
+              "AlternateCoreName": "mgba",
+              "Default": true
+            }
+          ]
+        }
+      ]
+    },
+    "Bios": [
+      {
+        "hash": "a860e8c0b6d573d191e4ec7db1b1e4f6",
+        "description": "[BIOS] Game Boy Advance (World).gba",
+        "filename": "gba_bios.bin"
+      },
+      {
+        "hash": "dbfce9db9deaa2567f6a84fde55f9680",
+        "description": "[BIOS] Nintendo Game Boy Color Boot ROM (World).gbc",
+        "filename": "gbc_bios.bin"
+      },
+      {
+        "hash": "32fbbd84168d3482956eb3c5051637f5",
+        "description": "[BIOS] Nintendo Game Boy Boot ROM (World) (Rev 1).gb",
+        "filename": "gb_bios.bin"
+      },
+      {
+        "hash": "d574d4f9c12f305074798f54c091a8b4",
+        "description": "SGB-CPU (World) (Enhancement Chip).bin",
+        "filename": "sgb_bios.bin"
+      }
+    ]
+  },
+  {
+    "IGDBId": 22,
+    "IGDBName": "Game Boy Color",
+    "IGDBSlug": "gbc",
+    "AlternateNames": [
+      "Game Boy Color",
+      "GBC"
+    ],
+    "Extensions": {
+      "SupportedFileExtensions": [
+        ".7Z",
+        ".GBC",
+        ".ZIP"
+      ],
+      "UniqueFileExtensions": [
+        ".GBC"
+      ]
+    },
+    "RetroPieDirectoryName": "gbc",
+    "WebEmulator": {
+      "Type": "EmulatorJS",
+      "Core": "gb",
+      "AvailableWebEmulators": [
+        {
+          "EmulatorType": "EmulatorJS",
+          "AvailableWebEmulatorCores": [
+            {
+              "Core": "gb",
+              "AlternateCoreName": "gambatte",
+              "Default": true
             },
             {
-                "hash": "32736f17079d0b2b7024407c39bd3050",
-                "description": "PS1 EU BIOS - Required for EU games",
-                "filename": "scph5502.bin"
+              "Core": "mgba",
+              "AlternateCoreName": "",
+              "Default": false
             }
-        ]
+          ]
+        }
+      ]
     },
-    {
-        "igdbId": 30,
-        "igdbName": "Sega 32X",
-        "igdbSlug": "sega32",
-        "alternateNames": [
-            "Sega 32X",
-            "Sega32",
-            "Sega32X"
-        ],
-        "extensions": {
-            "supportedFileExtensions": [
-                ".32X",
-                ".7Z",
-                ".BIN",
-                ".MD",
-                ".ZIP"
-            ],
-            "uniqueFileExtensions": [
-                ".32X"
-            ]
-        },
-        "retroPieDirectoryName": "sega32x",
-        "webEmulator": {
-            "type": "EmulatorJS",
-            "core": "sega32x",
-            "availableWebEmulators": [
-                {
-                    "emulatorType": "EmulatorJS",
-                    "availableWebEmulatorCores": [
-                        {
-                            "core": "sega32x",
-                            "alternateCoreName": "picodrive",
-                            "default": true
-                        }
-                    ]
-                }
-            ]
-        },
-        "bios": []
+    "Bios": [
+      {
+        "hash": "dbfce9db9deaa2567f6a84fde55f9680",
+        "description": "BIOS for Game Boy Color",
+        "filename": "gbc_bios.bin"
+      },
+      {
+        "hash": "d574d4f9c12f305074798f54c091a8b4",
+        "description": "Super Game Boy",
+        "filename": "sgb_bios.bin"
+      }
+    ]
+  },
+  {
+    "IGDBId": 379,
+    "IGDBName": "Game.com",
+    "IGDBSlug": "game-dot-com",
+    "AlternateNames": [
+      "Tiger Game.com"
+    ],
+    "Extensions": {
+      "SupportedFileExtensions": [],
+      "UniqueFileExtensions": []
     },
-    {
-        "igdbId": 78,
-        "igdbName": "Sega CD",
-        "igdbSlug": "segacd",
-        "alternateNames": [
-            "Mega CD",
-            "Sega CD",
-            "Sega Mega-CD & Sega CD",
-            "segacd"
-        ],
-        "extensions": {
-            "supportedFileExtensions": [
-                ".BIN",
-                ".CHD",
-                ".CUE",
-                ".ISO",
-                ".M3U"
-            ],
-            "uniqueFileExtensions": []
-        },
-        "retroPieDirectoryName": "segacd",
-        "webEmulator": {
-            "type": "EmulatorJS",
-            "core": "segaCD",
-            "availableWebEmulators": [
-                {
-                    "emulatorType": "EmulatorJS",
-                    "availableWebEmulatorCores": [
-                        {
-                            "core": "segaCD",
-                            "alternateCoreName": "genesis_plus_gx",
-                            "default": true
-                        },
-                        {
-                            "core": "picodrive"
-                        }
-                    ]
-                }
-            ]
-        },
-        "bios": [
+    "RetroPieDirectoryName": "",
+    "WebEmulator": {
+      "Type": "",
+      "Core": "",
+      "AvailableWebEmulators": null
+    },
+    "Bios": []
+  },
+  {
+    "IGDBId": 170,
+    "IGDBName": "Google Stadia",
+    "IGDBSlug": "stadia",
+    "AlternateNames": [
+      "Stadia"
+    ],
+    "Extensions": {
+      "SupportedFileExtensions": [],
+      "UniqueFileExtensions": []
+    },
+    "RetroPieDirectoryName": "",
+    "WebEmulator": {
+      "Type": "",
+      "Core": "",
+      "AvailableWebEmulators": null
+    },
+    "Bios": []
+  },
+  {
+    "IGDBId": 411,
+    "IGDBName": "Handheld Electronic LCD",
+    "IGDBSlug": "handheld-electronic-lcd",
+    "AlternateNames": [
+      "Handheld LCD Game"
+    ],
+    "Extensions": {
+      "SupportedFileExtensions": [],
+      "UniqueFileExtensions": []
+    },
+    "RetroPieDirectoryName": "",
+    "WebEmulator": {
+      "Type": "",
+      "Core": "",
+      "AvailableWebEmulators": null
+    },
+    "Bios": []
+  },
+  {
+    "IGDBId": 67,
+    "IGDBName": "Intellivision",
+    "IGDBSlug": "intellivision",
+    "AlternateNames": [],
+    "Extensions": {
+      "SupportedFileExtensions": [],
+      "UniqueFileExtensions": []
+    },
+    "RetroPieDirectoryName": "",
+    "WebEmulator": {
+      "Type": "",
+      "Core": "",
+      "AvailableWebEmulators": null
+    },
+    "Bios": []
+  },
+  {
+    "IGDBId": 382,
+    "IGDBName": "Intellivision Amico",
+    "IGDBSlug": "intellivision-amico",
+    "AlternateNames": [],
+    "Extensions": {
+      "SupportedFileExtensions": [],
+      "UniqueFileExtensions": []
+    },
+    "RetroPieDirectoryName": "",
+    "WebEmulator": {
+      "Type": "",
+      "Core": "",
+      "AvailableWebEmulators": null
+    },
+    "Bios": []
+  },
+  {
+    "IGDBId": 39,
+    "IGDBName": "iOS",
+    "IGDBSlug": "ios",
+    "AlternateNames": [],
+    "Extensions": {
+      "SupportedFileExtensions": [],
+      "UniqueFileExtensions": []
+    },
+    "RetroPieDirectoryName": "",
+    "WebEmulator": {
+      "Type": "",
+      "Core": "",
+      "AvailableWebEmulators": null
+    },
+    "Bios": []
+  },
+  {
+    "IGDBId": 413,
+    "IGDBName": "Leapster Explorer/LeadPad Explorer",
+    "IGDBSlug": "leapster-explorer-slash-leadpad-explorer",
+    "AlternateNames": [],
+    "Extensions": {
+      "SupportedFileExtensions": [],
+      "UniqueFileExtensions": []
+    },
+    "RetroPieDirectoryName": "",
+    "WebEmulator": {
+      "Type": "",
+      "Core": "",
+      "AvailableWebEmulators": null
+    },
+    "Bios": []
+  },
+  {
+    "IGDBId": 409,
+    "IGDBName": "Legacy Computer",
+    "IGDBSlug": "legacy-computer",
+    "AlternateNames": [],
+    "Extensions": {
+      "SupportedFileExtensions": [],
+      "UniqueFileExtensions": []
+    },
+    "RetroPieDirectoryName": "",
+    "WebEmulator": {
+      "Type": "",
+      "Core": "",
+      "AvailableWebEmulators": null
+    },
+    "Bios": []
+  },
+  {
+    "IGDBId": 55,
+    "IGDBName": "Legacy Mobile Device",
+    "IGDBSlug": "mobile",
+    "AlternateNames": [
+      "Legacy Cellphone"
+    ],
+    "Extensions": {
+      "SupportedFileExtensions": [],
+      "UniqueFileExtensions": []
+    },
+    "RetroPieDirectoryName": "",
+    "WebEmulator": {
+      "Type": "",
+      "Core": "",
+      "AvailableWebEmulators": null
+    },
+    "Bios": []
+  },
+  {
+    "IGDBId": 3,
+    "IGDBName": "Linux",
+    "IGDBSlug": "linux",
+    "AlternateNames": [
+      "GNU/Linux"
+    ],
+    "Extensions": {
+      "SupportedFileExtensions": [],
+      "UniqueFileExtensions": []
+    },
+    "RetroPieDirectoryName": "",
+    "WebEmulator": {
+      "Type": "",
+      "Core": "",
+      "AvailableWebEmulators": null
+    },
+    "Bios": []
+  },
+  {
+    "IGDBId": 14,
+    "IGDBName": "Mac",
+    "IGDBSlug": "mac",
+    "AlternateNames": [
+      "Mac OS"
+    ],
+    "Extensions": {
+      "SupportedFileExtensions": [],
+      "UniqueFileExtensions": []
+    },
+    "RetroPieDirectoryName": "",
+    "WebEmulator": {
+      "Type": "",
+      "Core": "",
+      "AvailableWebEmulators": null
+    },
+    "Bios": []
+  },
+  {
+    "IGDBId": 386,
+    "IGDBName": "Meta Quest 2",
+    "IGDBSlug": "meta-quest-2",
+    "AlternateNames": [
+      "Quest 2"
+    ],
+    "Extensions": {
+      "SupportedFileExtensions": [],
+      "UniqueFileExtensions": []
+    },
+    "RetroPieDirectoryName": "",
+    "WebEmulator": {
+      "Type": "",
+      "Core": "",
+      "AvailableWebEmulators": null
+    },
+    "Bios": []
+  },
+  {
+    "IGDBId": 112,
+    "IGDBName": "Microcomputer",
+    "IGDBSlug": "microcomputer--1",
+    "AlternateNames": [],
+    "Extensions": {
+      "SupportedFileExtensions": [],
+      "UniqueFileExtensions": []
+    },
+    "RetroPieDirectoryName": "",
+    "WebEmulator": {
+      "Type": "",
+      "Core": "",
+      "AvailableWebEmulators": null
+    },
+    "Bios": []
+  },
+  {
+    "IGDBId": 27,
+    "IGDBName": "MSX",
+    "IGDBSlug": "msx",
+    "AlternateNames": [],
+    "Extensions": {
+      "SupportedFileExtensions": [],
+      "UniqueFileExtensions": []
+    },
+    "RetroPieDirectoryName": "",
+    "WebEmulator": {
+      "Type": "",
+      "Core": "",
+      "AvailableWebEmulators": null
+    },
+    "Bios": []
+  },
+  {
+    "IGDBId": 53,
+    "IGDBName": "MSX2",
+    "IGDBSlug": "msx2",
+    "AlternateNames": [],
+    "Extensions": {
+      "SupportedFileExtensions": [],
+      "UniqueFileExtensions": []
+    },
+    "RetroPieDirectoryName": "",
+    "WebEmulator": {
+      "Type": "",
+      "Core": "",
+      "AvailableWebEmulators": null
+    },
+    "Bios": []
+  },
+  {
+    "IGDBId": 157,
+    "IGDBName": "NEC PC-6000 Series",
+    "IGDBSlug": "nec-pc-6000-series",
+    "AlternateNames": [],
+    "Extensions": {
+      "SupportedFileExtensions": [],
+      "UniqueFileExtensions": []
+    },
+    "RetroPieDirectoryName": "",
+    "WebEmulator": {
+      "Type": "",
+      "Core": "",
+      "AvailableWebEmulators": null
+    },
+    "Bios": []
+  },
+  {
+    "IGDBId": 80,
+    "IGDBName": "Neo Geo AES",
+    "IGDBSlug": "neogeoaes",
+    "AlternateNames": [
+      "AES"
+    ],
+    "Extensions": {
+      "SupportedFileExtensions": [],
+      "UniqueFileExtensions": []
+    },
+    "RetroPieDirectoryName": "",
+    "WebEmulator": {
+      "Type": "",
+      "Core": "",
+      "AvailableWebEmulators": null
+    },
+    "Bios": []
+  },
+  {
+    "IGDBId": 136,
+    "IGDBName": "Neo Geo CD",
+    "IGDBSlug": "neo-geo-cd",
+    "AlternateNames": [
+      "NGCD"
+    ],
+    "Extensions": {
+      "SupportedFileExtensions": [],
+      "UniqueFileExtensions": []
+    },
+    "RetroPieDirectoryName": "",
+    "WebEmulator": {
+      "Type": "",
+      "Core": "",
+      "AvailableWebEmulators": null
+    },
+    "Bios": []
+  },
+  {
+    "IGDBId": 79,
+    "IGDBName": "Neo Geo MVS",
+    "IGDBSlug": "neogeomvs",
+    "AlternateNames": [
+      "Neo Geo Multi Video System"
+    ],
+    "Extensions": {
+      "SupportedFileExtensions": [],
+      "UniqueFileExtensions": []
+    },
+    "RetroPieDirectoryName": "",
+    "WebEmulator": {
+      "Type": "",
+      "Core": "",
+      "AvailableWebEmulators": null
+    },
+    "Bios": []
+  },
+  {
+    "IGDBId": 120,
+    "IGDBName": "Neo Geo Pocket Color",
+    "IGDBSlug": "neo-geo-pocket-color",
+    "AlternateNames": [
+      "NGPC"
+    ],
+    "Extensions": {
+      "SupportedFileExtensions": [],
+      "UniqueFileExtensions": []
+    },
+    "RetroPieDirectoryName": "",
+    "WebEmulator": {
+      "Type": "EmulatorJS",
+      "Core": "mednafen_ngp",
+      "AvailableWebEmulators": [
+        {
+          "EmulatorType": "EmulatorJS",
+          "AvailableWebEmulatorCores": [
             {
-                "hash": "e66fa1dc5820d254611fdcdba0662372",
-                "description": "MegaCD EU BIOS - Required",
-                "filename": "bios_CD_E.bin"
+              "Core": "mednafen_ngp",
+              "AlternateCoreName": "",
+              "Default": true
+            }
+          ]
+        }
+      ]
+    },
+    "Bios": []
+  },
+  {
+    "IGDBId": 137,
+    "IGDBName": "New Nintendo 3DS",
+    "IGDBSlug": "new-nintendo-3ds",
+    "AlternateNames": [
+      "n3DS"
+    ],
+    "Extensions": {
+      "SupportedFileExtensions": [],
+      "UniqueFileExtensions": []
+    },
+    "RetroPieDirectoryName": "",
+    "WebEmulator": {
+      "Type": "",
+      "Core": "",
+      "AvailableWebEmulators": null
+    },
+    "Bios": []
+  },
+  {
+    "IGDBId": 37,
+    "IGDBName": "Nintendo 3DS",
+    "IGDBSlug": "3ds",
+    "AlternateNames": [
+      "3DS"
+    ],
+    "Extensions": {
+      "SupportedFileExtensions": [],
+      "UniqueFileExtensions": []
+    },
+    "RetroPieDirectoryName": "",
+    "WebEmulator": {
+      "Type": "",
+      "Core": "",
+      "AvailableWebEmulators": null
+    },
+    "Bios": []
+  },
+  {
+    "IGDBId": 4,
+    "IGDBName": "Nintendo 64",
+    "IGDBSlug": "n64",
+    "AlternateNames": [
+      "N64",
+      "Nintendo 64"
+    ],
+    "Extensions": {
+      "SupportedFileExtensions": [
+        ".N64",
+        ".V64",
+        ".Z64",
+        ".ZIP"
+      ],
+      "UniqueFileExtensions": [
+        ".N64",
+        ".V64",
+        ".Z64"
+      ]
+    },
+    "RetroPieDirectoryName": "n64",
+    "WebEmulator": {
+      "Type": "EmulatorJS",
+      "Core": "n64",
+      "AvailableWebEmulators": [
+        {
+          "EmulatorType": "EmulatorJS",
+          "AvailableWebEmulatorCores": [
+            {
+              "Core": "n64",
+              "AlternateCoreName": "mupen64plus_next",
+              "Default": true
+            }
+          ]
+        }
+      ]
+    },
+    "Bios": []
+  },
+  {
+    "IGDBId": 20,
+    "IGDBName": "Nintendo DS",
+    "IGDBSlug": "nds",
+    "AlternateNames": [
+      "NDS"
+    ],
+    "Extensions": {
+      "SupportedFileExtensions": [
+        ".BIN",
+        ".NDS",
+        ".ZIP"
+      ],
+      "UniqueFileExtensions": [
+        ".NDS"
+      ]
+    },
+    "RetroPieDirectoryName": "nds",
+    "WebEmulator": {
+      "Type": "EmulatorJS",
+      "Core": "nds",
+      "AvailableWebEmulators": [
+        {
+          "EmulatorType": "EmulatorJS",
+          "AvailableWebEmulatorCores": [
+            {
+              "Core": "nds",
+              "AlternateCoreName": "melonds",
+              "Default": true
             },
             {
-                "hash": "278a9397d192149e84e820ac621a8edd",
-                "description": "MegaCD JP BIOS - Required",
-                "filename": "bios_CD_J.bin"
+              "Core": "desmume2015",
+              "AlternateCoreName": "",
+              "Default": false
+            }
+          ]
+        }
+      ]
+    },
+    "Bios": [
+      {
+        "hash": "df692a80a5b1bc90728bc3dfc76cd948",
+        "description": "ARM7 BIOS",
+        "filename": "bios7.bin"
+      },
+      {
+        "hash": "a392174eb3e572fed6447e956bde4b25",
+        "description": "ARM9 BIOS",
+        "filename": "bios9.bin"
+      },
+      {
+        "hash": "145eaef5bd3037cbc247c213bb3da1b3",
+        "description": "NDS Firmware",
+        "filename": "firmware.bin"
+      }
+    ]
+  },
+  {
+    "IGDBId": 159,
+    "IGDBName": "Nintendo DSi",
+    "IGDBSlug": "nintendo-dsi",
+    "AlternateNames": [],
+    "Extensions": {
+      "SupportedFileExtensions": [],
+      "UniqueFileExtensions": []
+    },
+    "RetroPieDirectoryName": "",
+    "WebEmulator": {
+      "Type": "",
+      "Core": "",
+      "AvailableWebEmulators": null
+    },
+    "Bios": []
+  },
+  {
+    "IGDBId": 18,
+    "IGDBName": "Nintendo Entertainment System",
+    "IGDBSlug": "nes",
+    "AlternateNames": [
+      "NES",
+      "Nintendo Entertainment System",
+      "Nintendo Famicom & Entertainment System"
+    ],
+    "Extensions": {
+      "SupportedFileExtensions": [
+        ".7Z",
+        ".FDS",
+        ".NES",
+        ".NEZ",
+        ".UNF",
+        ".UNIF",
+        ".ZIP"
+      ],
+      "UniqueFileExtensions": [
+        ".FDS",
+        ".NES",
+        ".NEZ",
+        ".UNF",
+        ".UNIF"
+      ]
+    },
+    "RetroPieDirectoryName": "nes",
+    "WebEmulator": {
+      "Type": "EmulatorJS",
+      "Core": "nes",
+      "AvailableWebEmulators": [
+        {
+          "EmulatorType": "EmulatorJS",
+          "AvailableWebEmulatorCores": [
+            {
+              "Core": "nes",
+              "AlternateCoreName": "fceumm",
+              "Default": true
             },
             {
-                "hash": "2efd74e3232ff260e371b99f84024f7f",
-                "description": "SegaCD US BIOS - Required",
-                "filename": "bios_CD_U.bin"
+              "Core": "nestopia",
+              "AlternateCoreName": "",
+              "Default": false
             }
-        ]
+          ]
+        }
+      ]
     },
-    {
-        "igdbId": 35,
-        "igdbName": "Sega Game Gear",
-        "igdbSlug": "gamegear",
-        "alternateNames": [
-            "Game Gear",
-            "gamegear",
-            "GG",
-            "Sega Game Gear"
-        ],
-        "extensions": {
-            "supportedFileExtensions": [
-                ".7Z",
-                ".BIN",
-                ".GG",
-                ".ZIP"
-            ],
-            "uniqueFileExtensions": [
-                ".GG"
-            ]
-        },
-        "retroPieDirectoryName": "gamegear",
-        "webEmulator": {
-            "type": "EmulatorJS",
-            "core": "segaGG",
-            "availableWebEmulators": [
-                {
-                    "emulatorType": "EmulatorJS",
-                    "availableWebEmulatorCores": [
-                        {
-                            "core": "segaGG",
-                            "alternateCoreName": "genesis_plus_gx",
-                            "default": true
-                        }
-                    ]
-                }
-            ]
-        },
-        "bios": [
+    "Bios": [
+      {
+        "hash": "ca30b50f880eb660a320674ed365ef7a",
+        "description": "Family Computer Disk System BIOS - Required for Famicom Disk System emulation",
+        "filename": "disksys.rom"
+      },
+      {
+        "hash": "7f98d77d7a094ad7d069b74bd553ec98",
+        "description": "Game Genie add-on cartridge - Required for Game Genei Add-on emulation (Only supported on the fceumm core)",
+        "filename": "gamegenie.nes"
+      }
+    ]
+  },
+  {
+    "IGDBId": 21,
+    "IGDBName": "Nintendo GameCube",
+    "IGDBSlug": "ngc",
+    "AlternateNames": [
+      "GameCube",
+      "GC",
+      "GCN",
+      "ngc",
+      "Nintendo GameCube"
+    ],
+    "Extensions": {
+      "SupportedFileExtensions": [
+        ".CISO",
+        ".GC",
+        ".GCM",
+        ".GCZ",
+        ".ISO",
+        ".RVZ"
+      ],
+      "UniqueFileExtensions": [
+        ".CISO",
+        ".GC",
+        ".GCM",
+        ".GCZ",
+        ".RVZ"
+      ]
+    },
+    "RetroPieDirectoryName": "gc",
+    "WebEmulator": {
+      "Type": "",
+      "Core": "",
+      "AvailableWebEmulators": []
+    },
+    "Bios": []
+  },
+  {
+    "IGDBId": 130,
+    "IGDBName": "Nintendo Switch",
+    "IGDBSlug": "switch",
+    "AlternateNames": [
+      "NX"
+    ],
+    "Extensions": {
+      "SupportedFileExtensions": [],
+      "UniqueFileExtensions": []
+    },
+    "RetroPieDirectoryName": "",
+    "WebEmulator": {
+      "Type": "",
+      "Core": "",
+      "AvailableWebEmulators": null
+    },
+    "Bios": []
+  },
+  {
+    "IGDBId": 384,
+    "IGDBName": "Oculus Quest",
+    "IGDBSlug": "oculus-quest",
+    "AlternateNames": [
+      "Quest"
+    ],
+    "Extensions": {
+      "SupportedFileExtensions": [],
+      "UniqueFileExtensions": []
+    },
+    "RetroPieDirectoryName": "",
+    "WebEmulator": {
+      "Type": "",
+      "Core": "",
+      "AvailableWebEmulators": null
+    },
+    "Bios": []
+  },
+  {
+    "IGDBId": 162,
+    "IGDBName": "Oculus VR",
+    "IGDBSlug": "oculus-vr",
+    "AlternateNames": [],
+    "Extensions": {
+      "SupportedFileExtensions": [],
+      "UniqueFileExtensions": []
+    },
+    "RetroPieDirectoryName": "",
+    "WebEmulator": {
+      "Type": "",
+      "Core": "",
+      "AvailableWebEmulators": null
+    },
+    "Bios": []
+  },
+  {
+    "IGDBId": 88,
+    "IGDBName": "Odyssey",
+    "IGDBSlug": "odyssey--1",
+    "AlternateNames": [
+      "Magnavox Odyssey; Odysee; Odisea; Odissea"
+    ],
+    "Extensions": {
+      "SupportedFileExtensions": [],
+      "UniqueFileExtensions": []
+    },
+    "RetroPieDirectoryName": "",
+    "WebEmulator": {
+      "Type": "",
+      "Core": "",
+      "AvailableWebEmulators": null
+    },
+    "Bios": []
+  },
+  {
+    "IGDBId": 133,
+    "IGDBName": "Odyssey 2 / Videopac G7000",
+    "IGDBSlug": "odyssey-2-slash-videopac-g7000",
+    "AlternateNames": [
+      "Magnavox Odyssey²"
+    ],
+    "Extensions": {
+      "SupportedFileExtensions": [],
+      "UniqueFileExtensions": []
+    },
+    "RetroPieDirectoryName": "",
+    "WebEmulator": {
+      "Type": "",
+      "Core": "",
+      "AvailableWebEmulators": null
+    },
+    "Bios": []
+  },
+  {
+    "IGDBId": 72,
+    "IGDBName": "Ouya",
+    "IGDBSlug": "ouya",
+    "AlternateNames": [],
+    "Extensions": {
+      "SupportedFileExtensions": [],
+      "UniqueFileExtensions": []
+    },
+    "RetroPieDirectoryName": "",
+    "WebEmulator": {
+      "Type": "",
+      "Core": "",
+      "AvailableWebEmulators": null
+    },
+    "Bios": []
+  },
+  {
+    "IGDBId": 6,
+    "IGDBName": "PC (Microsoft Windows)",
+    "IGDBSlug": "win",
+    "AlternateNames": [
+      "mswin"
+    ],
+    "Extensions": {
+      "SupportedFileExtensions": [],
+      "UniqueFileExtensions": []
+    },
+    "RetroPieDirectoryName": "",
+    "WebEmulator": {
+      "Type": "",
+      "Core": "",
+      "AvailableWebEmulators": null
+    },
+    "Bios": []
+  },
+  {
+    "IGDBId": 142,
+    "IGDBName": "PC-50X Family",
+    "IGDBSlug": "pc-50x-family",
+    "AlternateNames": [],
+    "Extensions": {
+      "SupportedFileExtensions": [],
+      "UniqueFileExtensions": []
+    },
+    "RetroPieDirectoryName": "",
+    "WebEmulator": {
+      "Type": "",
+      "Core": "",
+      "AvailableWebEmulators": null
+    },
+    "Bios": []
+  },
+  {
+    "IGDBId": 125,
+    "IGDBName": "PC-8800 Series",
+    "IGDBSlug": "pc-8800-series",
+    "AlternateNames": [],
+    "Extensions": {
+      "SupportedFileExtensions": [],
+      "UniqueFileExtensions": []
+    },
+    "RetroPieDirectoryName": "",
+    "WebEmulator": {
+      "Type": "",
+      "Core": "",
+      "AvailableWebEmulators": null
+    },
+    "Bios": []
+  },
+  {
+    "IGDBId": 149,
+    "IGDBName": "PC-9800 Series",
+    "IGDBSlug": "pc-9800-series",
+    "AlternateNames": [
+      "PC-98"
+    ],
+    "Extensions": {
+      "SupportedFileExtensions": [],
+      "UniqueFileExtensions": []
+    },
+    "RetroPieDirectoryName": "",
+    "WebEmulator": {
+      "Type": "",
+      "Core": "",
+      "AvailableWebEmulators": null
+    },
+    "Bios": []
+  },
+  {
+    "IGDBId": 274,
+    "IGDBName": "PC-FX",
+    "IGDBSlug": "pc-fx",
+    "AlternateNames": [
+      "NEC PC-FX",
+      "PC-FX"
+    ],
+    "Extensions": {
+      "SupportedFileExtensions": [],
+      "UniqueFileExtensions": []
+    },
+    "RetroPieDirectoryName": "",
+    "WebEmulator": {
+      "Type": "EmulatorJS",
+      "Core": "mednafen_pcfx",
+      "AvailableWebEmulators": [
+        {
+          "EmulatorType": "EmulatorJS",
+          "AvailableWebEmulatorCores": [
             {
-                "hash": "672e104c3be3a238301aceffc3b23fd6",
-                "description": "GameGear BIOS (bootrom) - Optional",
-                "filename": "bios.gg"
+              "Core": "mednafen_pcfx",
+              "AlternateCoreName": "mednafen_pcfx",
+              "Default": true
             }
-        ]
+          ]
+        }
+      ]
     },
-    {
-        "igdbId": 64,
-        "igdbName": "Sega Master System/Mark III",
-        "igdbSlug": "sms",
-        "alternateNames": [
-            "Sega Mark III & Master System",
-            "Sega Master System",
-            "Sega Master System/Mark III",
-            "sms",
-            "SMS, Mark III"
-        ],
-        "extensions": {
-            "supportedFileExtensions": [
-                ".7Z",
-                ".BIN",
-                ".SMS",
-                ".ZIP"
-            ],
-            "uniqueFileExtensions": [
-                ".SMS"
-            ]
-        },
-        "retroPieDirectoryName": "mastersystem",
-        "webEmulator": {
-            "type": "EmulatorJS",
-            "core": "picodrive",
-            "availableWebEmulators": [
-                {
-                    "emulatorType": "EmulatorJS",
-                    "availableWebEmulatorCores": [
-                        {
-                            "core": "picodrive",
-                            "default": true
-                        },
-                        {
-                            "core": "segaMS",
-                            "alternateCoreName": "genesis_plus_gx"
-                        }
-                    ]
-                }
-            ]
-        },
-        "bios": [
+    "Bios": []
+  },
+  {
+    "IGDBId": 96,
+    "IGDBName": "PDP-10",
+    "IGDBSlug": "pdp10",
+    "AlternateNames": [],
+    "Extensions": {
+      "SupportedFileExtensions": [],
+      "UniqueFileExtensions": []
+    },
+    "RetroPieDirectoryName": "",
+    "WebEmulator": {
+      "Type": "",
+      "Core": "",
+      "AvailableWebEmulators": null
+    },
+    "Bios": []
+  },
+  {
+    "IGDBId": 108,
+    "IGDBName": "PDP-11",
+    "IGDBSlug": "pdp11",
+    "AlternateNames": [],
+    "Extensions": {
+      "SupportedFileExtensions": [],
+      "UniqueFileExtensions": []
+    },
+    "RetroPieDirectoryName": "",
+    "WebEmulator": {
+      "Type": "",
+      "Core": "",
+      "AvailableWebEmulators": null
+    },
+    "Bios": []
+  },
+  {
+    "IGDBId": 97,
+    "IGDBName": "PDP-8",
+    "IGDBSlug": "pdp-8--1",
+    "AlternateNames": [],
+    "Extensions": {
+      "SupportedFileExtensions": [],
+      "UniqueFileExtensions": []
+    },
+    "RetroPieDirectoryName": "",
+    "WebEmulator": {
+      "Type": "",
+      "Core": "",
+      "AvailableWebEmulators": null
+    },
+    "Bios": []
+  },
+  {
+    "IGDBId": 117,
+    "IGDBName": "Philips CD-i",
+    "IGDBSlug": "philips-cd-i",
+    "AlternateNames": [],
+    "Extensions": {
+      "SupportedFileExtensions": [],
+      "UniqueFileExtensions": []
+    },
+    "RetroPieDirectoryName": "",
+    "WebEmulator": {
+      "Type": "",
+      "Core": "",
+      "AvailableWebEmulators": null
+    },
+    "Bios": []
+  },
+  {
+    "IGDBId": 381,
+    "IGDBName": "Playdate",
+    "IGDBSlug": "playdate",
+    "AlternateNames": [],
+    "Extensions": {
+      "SupportedFileExtensions": [],
+      "UniqueFileExtensions": []
+    },
+    "RetroPieDirectoryName": "",
+    "WebEmulator": {
+      "Type": "",
+      "Core": "",
+      "AvailableWebEmulators": null
+    },
+    "Bios": []
+  },
+  {
+    "IGDBId": 7,
+    "IGDBName": "PlayStation",
+    "IGDBSlug": "ps",
+    "AlternateNames": [
+      "PlayStation",
+      "PS",
+      "PS1",
+      "PSOne",
+      "PSX",
+      "PSX, PSOne, PS",
+      "Sony PlayStation"
+    ],
+    "Extensions": {
+      "SupportedFileExtensions": [
+        ".CCD",
+        ".CHD",
+        ".CUE",
+        ".EXE",
+        ".ISO",
+        ".M3U",
+        ".PBP",
+        ".TOC"
+      ],
+      "UniqueFileExtensions": [
+        ".CCD",
+        ".EXE",
+        ".PBP",
+        ".TOC"
+      ]
+    },
+    "RetroPieDirectoryName": "psx",
+    "WebEmulator": {
+      "Type": "EmulatorJS",
+      "Core": "psx",
+      "AvailableWebEmulators": [
+        {
+          "EmulatorType": "EmulatorJS",
+          "AvailableWebEmulatorCores": [
             {
-                "hash": "840481177270d5642a14ca71ee72844c",
-                "description": "MasterSystem EU BIOS",
-                "filename": "bios_E.sms"
+              "Core": "psx",
+              "AlternateCoreName": "pcsx_rearmed",
+              "Default": true
             },
             {
-                "hash": "24a519c53f67b00640d0048ef7089105",
-                "description": "MasterSystem JP BIOS",
-                "filename": "bios_J.sms"
+              "Core": "mednafen_psx",
+              "AlternateCoreName": "",
+              "Default": false
+            }
+          ]
+        }
+      ]
+    },
+    "Bios": [
+      {
+        "hash": "8dd7d5296a650fac7319bce665a6a53c",
+        "description": "PS1 JP BIOS - Required for JP games",
+        "filename": "scph5500.bin"
+      },
+      {
+        "hash": "490f666e1afb15b7362b406ed1cea246",
+        "description": "PS1 US BIOS - Required for US games",
+        "filename": "scph5501.bin"
+      },
+      {
+        "hash": "32736f17079d0b2b7024407c39bd3050",
+        "description": "PS1 EU BIOS - Required for EU games",
+        "filename": "scph5502.bin"
+      }
+    ]
+  },
+  {
+    "IGDBId": 8,
+    "IGDBName": "PlayStation 2",
+    "IGDBSlug": "ps2",
+    "AlternateNames": [
+      "PS2"
+    ],
+    "Extensions": {
+      "SupportedFileExtensions": [],
+      "UniqueFileExtensions": []
+    },
+    "RetroPieDirectoryName": "",
+    "WebEmulator": {
+      "Type": "",
+      "Core": "",
+      "AvailableWebEmulators": null
+    },
+    "Bios": []
+  },
+  {
+    "IGDBId": 9,
+    "IGDBName": "PlayStation 3",
+    "IGDBSlug": "ps3",
+    "AlternateNames": [
+      "PS3"
+    ],
+    "Extensions": {
+      "SupportedFileExtensions": [],
+      "UniqueFileExtensions": []
+    },
+    "RetroPieDirectoryName": "",
+    "WebEmulator": {
+      "Type": "",
+      "Core": "",
+      "AvailableWebEmulators": null
+    },
+    "Bios": []
+  },
+  {
+    "IGDBId": 48,
+    "IGDBName": "PlayStation 4",
+    "IGDBSlug": "ps4--1",
+    "AlternateNames": [
+      "PS4"
+    ],
+    "Extensions": {
+      "SupportedFileExtensions": [],
+      "UniqueFileExtensions": []
+    },
+    "RetroPieDirectoryName": "",
+    "WebEmulator": {
+      "Type": "",
+      "Core": "",
+      "AvailableWebEmulators": null
+    },
+    "Bios": []
+  },
+  {
+    "IGDBId": 167,
+    "IGDBName": "PlayStation 5",
+    "IGDBSlug": "ps5",
+    "AlternateNames": [
+      "PS5"
+    ],
+    "Extensions": {
+      "SupportedFileExtensions": [],
+      "UniqueFileExtensions": []
+    },
+    "RetroPieDirectoryName": "",
+    "WebEmulator": {
+      "Type": "",
+      "Core": "",
+      "AvailableWebEmulators": null
+    },
+    "Bios": []
+  },
+  {
+    "IGDBId": 38,
+    "IGDBName": "PlayStation Portable",
+    "IGDBSlug": "psp",
+    "AlternateNames": [
+      "PSP"
+    ],
+    "Extensions": {
+      "SupportedFileExtensions": [],
+      "UniqueFileExtensions": []
+    },
+    "RetroPieDirectoryName": "",
+    "WebEmulator": {
+      "Type": "",
+      "Core": "",
+      "AvailableWebEmulators": null
+    },
+    "Bios": []
+  },
+  {
+    "IGDBId": 46,
+    "IGDBName": "PlayStation Vita",
+    "IGDBSlug": "psvita",
+    "AlternateNames": [
+      "PS Vita"
+    ],
+    "Extensions": {
+      "SupportedFileExtensions": [],
+      "UniqueFileExtensions": []
+    },
+    "RetroPieDirectoryName": "",
+    "WebEmulator": {
+      "Type": "",
+      "Core": "",
+      "AvailableWebEmulators": null
+    },
+    "Bios": []
+  },
+  {
+    "IGDBId": 165,
+    "IGDBName": "PlayStation VR",
+    "IGDBSlug": "psvr",
+    "AlternateNames": [
+      "PSVR"
+    ],
+    "Extensions": {
+      "SupportedFileExtensions": [],
+      "UniqueFileExtensions": []
+    },
+    "RetroPieDirectoryName": "",
+    "WebEmulator": {
+      "Type": "",
+      "Core": "",
+      "AvailableWebEmulators": null
+    },
+    "Bios": []
+  },
+  {
+    "IGDBId": 377,
+    "IGDBName": "Plug & Play",
+    "IGDBSlug": "plug-and-play",
+    "AlternateNames": [
+      "TV Game"
+    ],
+    "Extensions": {
+      "SupportedFileExtensions": [],
+      "UniqueFileExtensions": []
+    },
+    "RetroPieDirectoryName": "",
+    "WebEmulator": {
+      "Type": "",
+      "Core": "",
+      "AvailableWebEmulators": null
+    },
+    "Bios": []
+  },
+  {
+    "IGDBId": 306,
+    "IGDBName": "Satellaview",
+    "IGDBSlug": "satellaview",
+    "AlternateNames": [],
+    "Extensions": {
+      "SupportedFileExtensions": [],
+      "UniqueFileExtensions": []
+    },
+    "RetroPieDirectoryName": "",
+    "WebEmulator": {
+      "Type": "",
+      "Core": "",
+      "AvailableWebEmulators": null
+    },
+    "Bios": []
+  },
+  {
+    "IGDBId": 30,
+    "IGDBName": "Sega 32X",
+    "IGDBSlug": "sega32",
+    "AlternateNames": [
+      "Sega 32X",
+      "Sega32",
+      "Sega32X"
+    ],
+    "Extensions": {
+      "SupportedFileExtensions": [
+        ".32X",
+        ".7Z",
+        ".BIN",
+        ".MD",
+        ".ZIP"
+      ],
+      "UniqueFileExtensions": [
+        ".32X"
+      ]
+    },
+    "RetroPieDirectoryName": "sega32x",
+    "WebEmulator": {
+      "Type": "EmulatorJS",
+      "Core": "sega32x",
+      "AvailableWebEmulators": [
+        {
+          "EmulatorType": "EmulatorJS",
+          "AvailableWebEmulatorCores": [
+            {
+              "Core": "sega32x",
+              "AlternateCoreName": "picodrive",
+              "Default": true
+            }
+          ]
+        }
+      ]
+    },
+    "Bios": []
+  },
+  {
+    "IGDBId": 78,
+    "IGDBName": "Sega CD",
+    "IGDBSlug": "segacd",
+    "AlternateNames": [
+      "Mega CD",
+      "Sega CD",
+      "Sega Mega-CD & Sega CD",
+      "segacd"
+    ],
+    "Extensions": {
+      "SupportedFileExtensions": [
+        ".BIN",
+        ".CHD",
+        ".CUE",
+        ".ISO",
+        ".M3U"
+      ],
+      "UniqueFileExtensions": []
+    },
+    "RetroPieDirectoryName": "segacd",
+    "WebEmulator": {
+      "Type": "EmulatorJS",
+      "Core": "segaCD",
+      "AvailableWebEmulators": [
+        {
+          "EmulatorType": "EmulatorJS",
+          "AvailableWebEmulatorCores": [
+            {
+              "Core": "segaCD",
+              "AlternateCoreName": "genesis_plus_gx",
+              "Default": true
             },
             {
-                "hash": "840481177270d5642a14ca71ee72844c",
-                "description": "MasterSystem US BIOS",
-                "filename": "bios_U.sms"
+              "Core": "picodrive",
+              "AlternateCoreName": "",
+              "Default": false
             }
-        ]
+          ]
+        }
+      ]
     },
-    {
-        "igdbId": 29,
-        "igdbName": "Sega Mega Drive/Genesis",
-        "igdbSlug": "genesis-slash-megadrive",
-        "alternateNames": [
-            "genesis-slash-megadrive",
-            "Sega Genesis",
-            "Sega Mega Drive",
-            "Sega Mega Drive & Genesis",
-            "Sega Mega Drive/Genesis"
-        ],
-        "extensions": {
-            "supportedFileExtensions": [
-                ".7Z",
-                ".BIN",
-                ".GEN",
-                ".MD",
-                ".SG",
-                ".SMD",
-                ".ZIP"
-            ],
-            "uniqueFileExtensions": [
-                ".GEN",
-                ".SG"
-            ]
-        },
-        "retroPieDirectoryName": "megadrive",
-        "webEmulator": {
-            "type": "EmulatorJS",
-            "core": "segaMD",
-            "availableWebEmulators": [
-                {
-                    "emulatorType": "EmulatorJS",
-                    "availableWebEmulatorCores": [
-                        {
-                            "core": "segaMD",
-                            "alternateCoreName": "genesis_plus_gx",
-                            "default": true
-                        },
-                        {
-                            "core": "picodrive"
-                        }
-                    ]
-                }
-            ]
-        },
-        "bios": [
+    "Bios": [
+      {
+        "hash": "e66fa1dc5820d254611fdcdba0662372",
+        "description": "MegaCD EU BIOS - Required",
+        "filename": "bios_CD_E.bin"
+      },
+      {
+        "hash": "278a9397d192149e84e820ac621a8edd",
+        "description": "MegaCD JP BIOS - Required",
+        "filename": "bios_CD_J.bin"
+      },
+      {
+        "hash": "2efd74e3232ff260e371b99f84024f7f",
+        "description": "SegaCD US BIOS - Required",
+        "filename": "bios_CD_U.bin"
+      }
+    ]
+  },
+  {
+    "IGDBId": 35,
+    "IGDBName": "Sega Game Gear",
+    "IGDBSlug": "gamegear",
+    "AlternateNames": [
+      "Game Gear",
+      "gamegear",
+      "GG",
+      "Sega Game Gear"
+    ],
+    "Extensions": {
+      "SupportedFileExtensions": [
+        ".7Z",
+        ".BIN",
+        ".GG",
+        ".ZIP"
+      ],
+      "UniqueFileExtensions": [
+        ".GG"
+      ]
+    },
+    "RetroPieDirectoryName": "gamegear",
+    "WebEmulator": {
+      "Type": "EmulatorJS",
+      "Core": "segaGG",
+      "AvailableWebEmulators": [
+        {
+          "EmulatorType": "EmulatorJS",
+          "AvailableWebEmulatorCores": [
             {
-                "hash": "45e298905a08f9cfb38fd504cd6dbc84",
-                "description": "MegaDrive TMSS startup ROM",
-                "filename": "bios_MD.bin"
+              "Core": "segaGG",
+              "AlternateCoreName": "genesis_plus_gx",
+              "Default": true
             }
-        ]
+          ]
+        }
+      ]
     },
-    {
-        "igdbId": 32,
-        "igdbName": "Sega Saturn",
-        "igdbSlug": "saturn",
-        "alternateNames": [
-            "Hi-Saturn",
-            "JVC Saturn",
-            "JVC Saturn, Hi-Saturn, Samsung Saturn, V-Saturn",
-            "Samsung Saturn",
-            "Saturn",
-            "Sega Saturn",
-            "V-Saturn"
-        ],
-        "extensions": {
-            "supportedFileExtensions": [
-                ".BIN",
-                ".CUE",
-                ".ISO",
-                ".MDF"
-            ],
-            "uniqueFileExtensions": [
-                ".MDF"
-            ]
-        },
-        "retroPieDirectoryName": "saturn",
-        "webEmulator": {
-            "type": "EmulatorJS",
-            "core": "segaSaturn",
-            "availableWebEmulators": [
-                {
-                    "emulatorType": "EmulatorJS",
-                    "availableWebEmulatorCores": [
-                        {
-                            "core": "segaSaturn",
-                            "alternateCoreName": "yabause",
-                            "default": true
-                        },
-                        {
-                            "core": "mgba"
-                        }
-                    ]
-                }
-            ]
-        },
-        "bios": [
+    "Bios": [
+      {
+        "hash": "672e104c3be3a238301aceffc3b23fd6",
+        "description": "GameGear BIOS (bootrom) - Optional",
+        "filename": "bios.gg"
+      }
+    ]
+  },
+  {
+    "IGDBId": 64,
+    "IGDBName": "Sega Master System/Mark III",
+    "IGDBSlug": "sms",
+    "AlternateNames": [
+      "Sega Mark III & Master System",
+      "Sega Master System",
+      "Sega Master System/Mark III",
+      "sms",
+      "SMS, Mark III"
+    ],
+    "Extensions": {
+      "SupportedFileExtensions": [
+        ".7Z",
+        ".BIN",
+        ".SMS",
+        ".ZIP"
+      ],
+      "UniqueFileExtensions": [
+        ".SMS"
+      ]
+    },
+    "RetroPieDirectoryName": "mastersystem",
+    "WebEmulator": {
+      "Type": "EmulatorJS",
+      "Core": "picodrive",
+      "AvailableWebEmulators": [
+        {
+          "EmulatorType": "EmulatorJS",
+          "AvailableWebEmulatorCores": [
             {
-                "hash": "af5828fdff51384f99b3c4926be27762",
-                "description": "Saturn BIOS",
-                "filename": "saturn_bios.bin"
+              "Core": "picodrive",
+              "AlternateCoreName": "",
+              "Default": true
+            },
+            {
+              "Core": "segaMS",
+              "AlternateCoreName": "genesis_plus_gx",
+              "Default": false
             }
-        ]
+          ]
+        }
+      ]
     },
-    {
-        "igdbId": 19,
-        "igdbName": "Super Nintendo Entertainment System",
-        "igdbSlug": "snes",
-        "alternateNames": [
-            "Nintendo Super Famicom & Super Entertainment System",
-            "SNES",
-            "SNES, Super Nintendo",
-            "Super Nintendo",
-            "Super Nintendo Entertainment System"
-        ],
-        "extensions": {
-            "supportedFileExtensions": [
-                ".7Z",
-                ".BIN",
-                ".BS",
-                ".FIG",
-                ".MGD",
-                ".SFC",
-                ".SMC",
-                ".SWC",
-                ".ZIP"
-            ],
-            "uniqueFileExtensions": [
-                ".BS",
-                ".FIG",
-                ".MGD",
-                ".SFC",
-                ".SMC",
-                ".SWC"
-            ]
-        },
-        "retroPieDirectoryName": "snes",
-        "webEmulator": {
-            "type": "EmulatorJS",
-            "core": "snes",
-            "availableWebEmulators": [
-                {
-                    "emulatorType": "EmulatorJS",
-                    "availableWebEmulatorCores": [
-                        {
-                            "core": "snes",
-                            "alternateCoreName": "snes9x",
-                            "default": true
-                        }
-                    ]
-                }
-            ]
-        },
-        "bios": []
+    "Bios": [
+      {
+        "hash": "840481177270d5642a14ca71ee72844c",
+        "description": "MasterSystem EU BIOS",
+        "filename": "bios_E.sms"
+      },
+      {
+        "hash": "24a519c53f67b00640d0048ef7089105",
+        "description": "MasterSystem JP BIOS",
+        "filename": "bios_J.sms"
+      },
+      {
+        "hash": "840481177270d5642a14ca71ee72844c",
+        "description": "MasterSystem US BIOS",
+        "filename": "bios_U.sms"
+      }
+    ]
+  },
+  {
+    "IGDBId": 29,
+    "IGDBName": "Sega Mega Drive/Genesis",
+    "IGDBSlug": "genesis-slash-megadrive",
+    "AlternateNames": [
+      "genesis-slash-megadrive",
+      "Sega Genesis",
+      "Sega Mega Drive",
+      "Sega Mega Drive & Genesis",
+      "Sega Mega Drive/Genesis"
+    ],
+    "Extensions": {
+      "SupportedFileExtensions": [
+        ".7Z",
+        ".BIN",
+        ".GEN",
+        ".MD",
+        ".SG",
+        ".SMD",
+        ".ZIP"
+      ],
+      "UniqueFileExtensions": [
+        ".GEN",
+        ".SG",
+        ".SMD"
+      ]
     },
-    {
-        "igdbId": 87,
-        "igdbName": "Virtual Boy",
-        "igdbSlug": "virtualboy",
-        "alternateNames": [
-            "VB"
-        ],
-        "extensions": {
-            "supportedFileExtensions": [
-                ".7Z",
-                ".VB",
-                ".ZIP"
-            ],
-            "uniqueFileExtensions": [
-                ".VB"
-            ]
-        },
-        "retroPieDirectoryName": "vb",
-        "webEmulator": {
-            "type": "EmulatorJS",
-            "core": "vb",
-            "availableWebEmulators": [
-                {
-                    "emulatorType": "EmulatorJS",
-                    "availableWebEmulatorCores": [
-                        {
-                            "core": "vb",
-                            "alternateCoreName": "beetle_vb",
-                            "default": true
-                        }
-                    ]
-                }
-            ]
-        },
-        "bios": []
+    "RetroPieDirectoryName": "megadrive",
+    "WebEmulator": {
+      "Type": "EmulatorJS",
+      "Core": "segaMD",
+      "AvailableWebEmulators": [
+        {
+          "EmulatorType": "EmulatorJS",
+          "AvailableWebEmulatorCores": [
+            {
+              "Core": "segaMD",
+              "AlternateCoreName": "genesis_plus_gx",
+              "Default": true
+            },
+            {
+              "Core": "picodrive",
+              "AlternateCoreName": "",
+              "Default": false
+            }
+          ]
+        }
+      ]
     },
-    {
-        "igdbId": 26,
-        "igdbName": "ZX Spectrum",
-        "igdbSlug": "zxs",
-        "alternateNames": [
-            "Sinclair ZX",
-            "Sinclair ZX Spectrum",
-            "ZX Spectrum",
-            "zxs"
-        ],
-        "extensions": {
-            "supportedFileExtensions": [
-                ".DSK",
-                ".GZ",
-                ".IMG",
-                ".MGT",
-                ".SCL",
-                ".SNA",
-                ".SZX",
-                ".TAP",
-                ".TRD",
-                ".TZX",
-                ".UDI",
-                ".Z80"
-            ],
-            "uniqueFileExtensions": [
-                ".MGT",
-                ".SCL",
-                ".SNA",
-                ".SZX",
-                ".TRD",
-                ".TZX",
-                ".UDI",
-                ".Z80"
-            ]
-        },
-        "retroPieDirectoryName": "zxspectrum",
-        "webEmulator": {
-            "type": "",
-            "core": ""
-        },
-        "bios": []
-    }
+    "Bios": [
+      {
+        "hash": "45e298905a08f9cfb38fd504cd6dbc84",
+        "description": "MegaDrive TMSS startup ROM",
+        "filename": "bios_MD.bin"
+      }
+    ]
+  },
+  {
+    "IGDBId": 32,
+    "IGDBName": "Sega Saturn",
+    "IGDBSlug": "saturn",
+    "AlternateNames": [
+      "Hi-Saturn",
+      "JVC Saturn",
+      "JVC Saturn, Hi-Saturn, Samsung Saturn, V-Saturn",
+      "Samsung Saturn",
+      "Saturn",
+      "Sega Saturn",
+      "V-Saturn"
+    ],
+    "Extensions": {
+      "SupportedFileExtensions": [
+        ".BIN",
+        ".CUE",
+        ".ISO",
+        ".MDF"
+      ],
+      "UniqueFileExtensions": [
+        ".MDF"
+      ]
+    },
+    "RetroPieDirectoryName": "saturn",
+    "WebEmulator": {
+      "Type": "EmulatorJS",
+      "Core": "segaSaturn",
+      "AvailableWebEmulators": [
+        {
+          "EmulatorType": "EmulatorJS",
+          "AvailableWebEmulatorCores": [
+            {
+              "Core": "segaSaturn",
+              "AlternateCoreName": "yabause",
+              "Default": true
+            },
+            {
+              "Core": "mgba",
+              "AlternateCoreName": "",
+              "Default": false
+            }
+          ]
+        }
+      ]
+    },
+    "Bios": [
+      {
+        "hash": "af5828fdff51384f99b3c4926be27762",
+        "description": "Saturn BIOS",
+        "filename": "saturn_bios.bin"
+      }
+    ]
+  },
+  {
+    "IGDBId": 84,
+    "IGDBName": "SG-1000",
+    "IGDBSlug": "sg1000",
+    "AlternateNames": [
+      "Sega Game 1000"
+    ],
+    "Extensions": {
+      "SupportedFileExtensions": [],
+      "UniqueFileExtensions": []
+    },
+    "RetroPieDirectoryName": "",
+    "WebEmulator": {
+      "Type": "",
+      "Core": "",
+      "AvailableWebEmulators": null
+    },
+    "Bios": []
+  },
+  {
+    "IGDBId": 374,
+    "IGDBName": "Sharp MZ-2200",
+    "IGDBSlug": "sharp-mz-2200",
+    "AlternateNames": [],
+    "Extensions": {
+      "SupportedFileExtensions": [],
+      "UniqueFileExtensions": []
+    },
+    "RetroPieDirectoryName": "",
+    "WebEmulator": {
+      "Type": "",
+      "Core": "",
+      "AvailableWebEmulators": null
+    },
+    "Bios": []
+  },
+  {
+    "IGDBId": 77,
+    "IGDBName": "Sharp X1",
+    "IGDBSlug": "x1",
+    "AlternateNames": [],
+    "Extensions": {
+      "SupportedFileExtensions": [],
+      "UniqueFileExtensions": []
+    },
+    "RetroPieDirectoryName": "",
+    "WebEmulator": {
+      "Type": "",
+      "Core": "",
+      "AvailableWebEmulators": null
+    },
+    "Bios": []
+  },
+  {
+    "IGDBId": 121,
+    "IGDBName": "Sharp X68000",
+    "IGDBSlug": "sharp-x68000",
+    "AlternateNames": [],
+    "Extensions": {
+      "SupportedFileExtensions": [],
+      "UniqueFileExtensions": []
+    },
+    "RetroPieDirectoryName": "",
+    "WebEmulator": {
+      "Type": "",
+      "Core": "",
+      "AvailableWebEmulators": null
+    },
+    "Bios": []
+  },
+  {
+    "IGDBId": 406,
+    "IGDBName": "Sinclair QL",
+    "IGDBSlug": "sinclair-ql",
+    "AlternateNames": [
+      "Sinclair Quantum Leap"
+    ],
+    "Extensions": {
+      "SupportedFileExtensions": [],
+      "UniqueFileExtensions": []
+    },
+    "RetroPieDirectoryName": "",
+    "WebEmulator": {
+      "Type": "",
+      "Core": "",
+      "AvailableWebEmulators": null
+    },
+    "Bios": []
+  },
+  {
+    "IGDBId": 373,
+    "IGDBName": "Sinclair ZX81",
+    "IGDBSlug": "sinclair-zx81",
+    "AlternateNames": [
+      "ZX81"
+    ],
+    "Extensions": {
+      "SupportedFileExtensions": [],
+      "UniqueFileExtensions": []
+    },
+    "RetroPieDirectoryName": "",
+    "WebEmulator": {
+      "Type": "",
+      "Core": "",
+      "AvailableWebEmulators": null
+    },
+    "Bios": []
+  },
+  {
+    "IGDBId": 163,
+    "IGDBName": "SteamVR",
+    "IGDBSlug": "steam-vr",
+    "AlternateNames": [],
+    "Extensions": {
+      "SupportedFileExtensions": [],
+      "UniqueFileExtensions": []
+    },
+    "RetroPieDirectoryName": "",
+    "WebEmulator": {
+      "Type": "",
+      "Core": "",
+      "AvailableWebEmulators": null
+    },
+    "Bios": []
+  },
+  {
+    "IGDBId": 58,
+    "IGDBName": "Super Famicom",
+    "IGDBSlug": "sfam",
+    "AlternateNames": [
+      "SFC"
+    ],
+    "Extensions": {
+      "SupportedFileExtensions": [],
+      "UniqueFileExtensions": []
+    },
+    "RetroPieDirectoryName": "",
+    "WebEmulator": {
+      "Type": "EmulatorJS",
+      "Core": "snes",
+      "AvailableWebEmulators": [
+        {
+          "EmulatorType": "EmulatorJS",
+          "AvailableWebEmulatorCores": [
+            {
+              "Core": "snes",
+              "AlternateCoreName": "snes9x",
+              "Default": true
+            }
+          ]
+        }
+      ]
+    },
+    "Bios": []
+  },
+  {
+    "IGDBId": 19,
+    "IGDBName": "Super Nintendo Entertainment System",
+    "IGDBSlug": "snes",
+    "AlternateNames": [
+      "Nintendo Super Famicom & Super Entertainment System",
+      "SNES",
+      "SNES, Super Nintendo",
+      "Super Nintendo",
+      "Super Nintendo Entertainment System"
+    ],
+    "Extensions": {
+      "SupportedFileExtensions": [
+        ".7Z",
+        ".BIN",
+        ".BS",
+        ".FIG",
+        ".MGD",
+        ".SFC",
+        ".SMC",
+        ".SWC",
+        ".ZIP"
+      ],
+      "UniqueFileExtensions": [
+        ".BS",
+        ".FIG",
+        ".MGD",
+        ".SFC",
+        ".SMC",
+        ".SWC"
+      ]
+    },
+    "RetroPieDirectoryName": "snes",
+    "WebEmulator": {
+      "Type": "EmulatorJS",
+      "Core": "snes",
+      "AvailableWebEmulators": [
+        {
+          "EmulatorType": "EmulatorJS",
+          "AvailableWebEmulatorCores": [
+            {
+              "Core": "snes",
+              "AlternateCoreName": "snes9x",
+              "Default": true
+            }
+          ]
+        }
+      ]
+    },
+    "Bios": []
+  },
+  {
+    "IGDBId": 44,
+    "IGDBName": "Tapwave Zodiac",
+    "IGDBSlug": "zod",
+    "AlternateNames": [],
+    "Extensions": {
+      "SupportedFileExtensions": [],
+      "UniqueFileExtensions": []
+    },
+    "RetroPieDirectoryName": "",
+    "WebEmulator": {
+      "Type": "",
+      "Core": "",
+      "AvailableWebEmulators": null
+    },
+    "Bios": []
+  },
+  {
+    "IGDBId": 155,
+    "IGDBName": "Tatung Einstein",
+    "IGDBSlug": "tatung-einstein",
+    "AlternateNames": [],
+    "Extensions": {
+      "SupportedFileExtensions": [],
+      "UniqueFileExtensions": []
+    },
+    "RetroPieDirectoryName": "",
+    "WebEmulator": {
+      "Type": "",
+      "Core": "",
+      "AvailableWebEmulators": null
+    },
+    "Bios": []
+  },
+  {
+    "IGDBId": 129,
+    "IGDBName": "Texas Instruments TI-99",
+    "IGDBSlug": "ti-99",
+    "AlternateNames": [
+      "Texas Instruments TI-99/4A"
+    ],
+    "Extensions": {
+      "SupportedFileExtensions": [],
+      "UniqueFileExtensions": []
+    },
+    "RetroPieDirectoryName": "",
+    "WebEmulator": {
+      "Type": "",
+      "Core": "",
+      "AvailableWebEmulators": null
+    },
+    "Bios": []
+  },
+  {
+    "IGDBId": 156,
+    "IGDBName": "Thomson MO5",
+    "IGDBSlug": "thomson-mo5",
+    "AlternateNames": [],
+    "Extensions": {
+      "SupportedFileExtensions": [],
+      "UniqueFileExtensions": []
+    },
+    "RetroPieDirectoryName": "",
+    "WebEmulator": {
+      "Type": "",
+      "Core": "",
+      "AvailableWebEmulators": null
+    },
+    "Bios": []
+  },
+  {
+    "IGDBId": 126,
+    "IGDBName": "TRS-80",
+    "IGDBSlug": "trs-80",
+    "AlternateNames": [],
+    "Extensions": {
+      "SupportedFileExtensions": [],
+      "UniqueFileExtensions": []
+    },
+    "RetroPieDirectoryName": "",
+    "WebEmulator": {
+      "Type": "",
+      "Core": "",
+      "AvailableWebEmulators": null
+    },
+    "Bios": []
+  },
+  {
+    "IGDBId": 151,
+    "IGDBName": "TRS-80 Color Computer",
+    "IGDBSlug": "trs-80-color-computer",
+    "AlternateNames": [
+      "Tandy Color Computer"
+    ],
+    "Extensions": {
+      "SupportedFileExtensions": [],
+      "UniqueFileExtensions": []
+    },
+    "RetroPieDirectoryName": "",
+    "WebEmulator": {
+      "Type": "",
+      "Core": "",
+      "AvailableWebEmulators": null
+    },
+    "Bios": []
+  },
+  {
+    "IGDBId": 86,
+    "IGDBName": "TurboGrafx-16/PC Engine",
+    "IGDBSlug": "turbografx16--1",
+    "AlternateNames": [],
+    "Extensions": {
+      "SupportedFileExtensions": [],
+      "UniqueFileExtensions": []
+    },
+    "RetroPieDirectoryName": "",
+    "WebEmulator": {
+      "Type": "EmulatorJS",
+      "Core": "mednafen_pce",
+      "AvailableWebEmulators": [
+        {
+          "EmulatorType": "EmulatorJS",
+          "AvailableWebEmulatorCores": [
+            {
+              "Core": "mednafen_pce",
+              "AlternateCoreName": "",
+              "Default": true
+            }
+          ]
+        }
+      ]
+    },
+    "Bios": []
+  },
+  {
+    "IGDBId": 150,
+    "IGDBName": "Turbografx-16/PC Engine CD",
+    "IGDBSlug": "turbografx-16-slash-pc-engine-cd",
+    "AlternateNames": [
+      "TG-16CD/PCECD"
+    ],
+    "Extensions": {
+      "SupportedFileExtensions": [],
+      "UniqueFileExtensions": []
+    },
+    "RetroPieDirectoryName": "",
+    "WebEmulator": {
+      "Type": "EmulatorJS",
+      "Core": "mednafen_pce",
+      "AvailableWebEmulators": [
+        {
+          "EmulatorType": "EmulatorJS",
+          "AvailableWebEmulatorCores": [
+            {
+              "Core": "mednafen_pce",
+              "AlternateCoreName": "",
+              "Default": true
+            }
+          ]
+        }
+      ]
+    },
+    "Bios": []
+  },
+  {
+    "IGDBId": 439,
+    "IGDBName": "V.Smile",
+    "IGDBSlug": "vsmile",
+    "AlternateNames": [
+      "V.SMILE TV LEARNING SYSTEM"
+    ],
+    "Extensions": {
+      "SupportedFileExtensions": [],
+      "UniqueFileExtensions": []
+    },
+    "RetroPieDirectoryName": "",
+    "WebEmulator": {
+      "Type": "",
+      "Core": "",
+      "AvailableWebEmulators": null
+    },
+    "Bios": []
+  },
+  {
+    "IGDBId": 138,
+    "IGDBName": "VC 4000",
+    "IGDBSlug": "vc-4000",
+    "AlternateNames": [],
+    "Extensions": {
+      "SupportedFileExtensions": [],
+      "UniqueFileExtensions": []
+    },
+    "RetroPieDirectoryName": "",
+    "WebEmulator": {
+      "Type": "",
+      "Core": "",
+      "AvailableWebEmulators": null
+    },
+    "Bios": []
+  },
+  {
+    "IGDBId": 70,
+    "IGDBName": "Vectrex",
+    "IGDBSlug": "vectrex",
+    "AlternateNames": [],
+    "Extensions": {
+      "SupportedFileExtensions": [],
+      "UniqueFileExtensions": []
+    },
+    "RetroPieDirectoryName": "",
+    "WebEmulator": {
+      "Type": "",
+      "Core": "",
+      "AvailableWebEmulators": null
+    },
+    "Bios": []
+  },
+  {
+    "IGDBId": 87,
+    "IGDBName": "Virtual Boy",
+    "IGDBSlug": "virtualboy",
+    "AlternateNames": [
+      "VB"
+    ],
+    "Extensions": {
+      "SupportedFileExtensions": [
+        ".7Z",
+        ".VB",
+        ".ZIP"
+      ],
+      "UniqueFileExtensions": [
+        ".VB"
+      ]
+    },
+    "RetroPieDirectoryName": "vb",
+    "WebEmulator": {
+      "Type": "EmulatorJS",
+      "Core": "vb",
+      "AvailableWebEmulators": [
+        {
+          "EmulatorType": "EmulatorJS",
+          "AvailableWebEmulatorCores": [
+            {
+              "Core": "vb",
+              "AlternateCoreName": "beetle_vb",
+              "Default": true
+            }
+          ]
+        }
+      ]
+    },
+    "Bios": []
+  },
+  {
+    "IGDBId": 82,
+    "IGDBName": "Web browser",
+    "IGDBSlug": "browser",
+    "AlternateNames": [
+      "Internet"
+    ],
+    "Extensions": {
+      "SupportedFileExtensions": [],
+      "UniqueFileExtensions": []
+    },
+    "RetroPieDirectoryName": "",
+    "WebEmulator": {
+      "Type": "",
+      "Core": "",
+      "AvailableWebEmulators": null
+    },
+    "Bios": []
+  },
+  {
+    "IGDBId": 5,
+    "IGDBName": "Wii",
+    "IGDBSlug": "wii",
+    "AlternateNames": [
+      "Revolution"
+    ],
+    "Extensions": {
+      "SupportedFileExtensions": [],
+      "UniqueFileExtensions": []
+    },
+    "RetroPieDirectoryName": "",
+    "WebEmulator": {
+      "Type": "",
+      "Core": "",
+      "AvailableWebEmulators": null
+    },
+    "Bios": []
+  },
+  {
+    "IGDBId": 41,
+    "IGDBName": "Wii U",
+    "IGDBSlug": "wiiu",
+    "AlternateNames": [
+      "Project Cafe"
+    ],
+    "Extensions": {
+      "SupportedFileExtensions": [],
+      "UniqueFileExtensions": []
+    },
+    "RetroPieDirectoryName": "",
+    "WebEmulator": {
+      "Type": "",
+      "Core": "",
+      "AvailableWebEmulators": null
+    },
+    "Bios": []
+  },
+  {
+    "IGDBId": 74,
+    "IGDBName": "Windows Phone",
+    "IGDBSlug": "winphone",
+    "AlternateNames": [
+      "WP"
+    ],
+    "Extensions": {
+      "SupportedFileExtensions": [],
+      "UniqueFileExtensions": []
+    },
+    "RetroPieDirectoryName": "",
+    "WebEmulator": {
+      "Type": "",
+      "Core": "",
+      "AvailableWebEmulators": null
+    },
+    "Bios": []
+  },
+  {
+    "IGDBId": 57,
+    "IGDBName": "WonderSwan",
+    "IGDBSlug": "wonderswan",
+    "AlternateNames": [
+      "WS"
+    ],
+    "Extensions": {
+      "SupportedFileExtensions": [],
+      "UniqueFileExtensions": []
+    },
+    "RetroPieDirectoryName": "",
+    "WebEmulator": {
+      "Type": "EmulatorJS",
+      "Core": "mednafen_wswan",
+      "AvailableWebEmulators": [
+        {
+          "EmulatorType": "EmulatorJS",
+          "AvailableWebEmulatorCores": [
+            {
+              "Core": "mednafen_wswan",
+              "AlternateCoreName": "",
+              "Default": true
+            }
+          ]
+        }
+      ]
+    },
+    "Bios": []
+  },
+  {
+    "IGDBId": 123,
+    "IGDBName": "WonderSwan Color",
+    "IGDBSlug": "wonderswan-color",
+    "AlternateNames": [
+      "WSC"
+    ],
+    "Extensions": {
+      "SupportedFileExtensions": [],
+      "UniqueFileExtensions": []
+    },
+    "RetroPieDirectoryName": "",
+    "WebEmulator": {
+      "Type": "EmulatorJS",
+      "Core": "mednafen_wswan",
+      "AvailableWebEmulators": [
+        {
+          "EmulatorType": "EmulatorJS",
+          "AvailableWebEmulatorCores": [
+            {
+              "Core": "mednafen_wswan",
+              "AlternateCoreName": "",
+              "Default": true
+            }
+          ]
+        }
+      ]
+    },
+    "Bios": []
+  },
+  {
+    "IGDBId": 11,
+    "IGDBName": "Xbox",
+    "IGDBSlug": "xbox",
+    "AlternateNames": [],
+    "Extensions": {
+      "SupportedFileExtensions": [],
+      "UniqueFileExtensions": []
+    },
+    "RetroPieDirectoryName": "",
+    "WebEmulator": {
+      "Type": "",
+      "Core": "",
+      "AvailableWebEmulators": null
+    },
+    "Bios": []
+  },
+  {
+    "IGDBId": 12,
+    "IGDBName": "Xbox 360",
+    "IGDBSlug": "xbox360",
+    "AlternateNames": [
+      "X360"
+    ],
+    "Extensions": {
+      "SupportedFileExtensions": [],
+      "UniqueFileExtensions": []
+    },
+    "RetroPieDirectoryName": "",
+    "WebEmulator": {
+      "Type": "",
+      "Core": "",
+      "AvailableWebEmulators": null
+    },
+    "Bios": []
+  },
+  {
+    "IGDBId": 49,
+    "IGDBName": "Xbox One",
+    "IGDBSlug": "xboxone",
+    "AlternateNames": [
+      "XONE"
+    ],
+    "Extensions": {
+      "SupportedFileExtensions": [],
+      "UniqueFileExtensions": []
+    },
+    "RetroPieDirectoryName": "",
+    "WebEmulator": {
+      "Type": "",
+      "Core": "",
+      "AvailableWebEmulators": null
+    },
+    "Bios": []
+  },
+  {
+    "IGDBId": 169,
+    "IGDBName": "Xbox Series X|S",
+    "IGDBSlug": "series-x",
+    "AlternateNames": [
+      "XSX"
+    ],
+    "Extensions": {
+      "SupportedFileExtensions": [],
+      "UniqueFileExtensions": []
+    },
+    "RetroPieDirectoryName": "",
+    "WebEmulator": {
+      "Type": "",
+      "Core": "",
+      "AvailableWebEmulators": null
+    },
+    "Bios": []
+  },
+  {
+    "IGDBId": 240,
+    "IGDBName": "Zeebo",
+    "IGDBSlug": "zeebo",
+    "AlternateNames": [],
+    "Extensions": {
+      "SupportedFileExtensions": [],
+      "UniqueFileExtensions": []
+    },
+    "RetroPieDirectoryName": "",
+    "WebEmulator": {
+      "Type": "",
+      "Core": "",
+      "AvailableWebEmulators": null
+    },
+    "Bios": []
+  },
+  {
+    "IGDBId": 26,
+    "IGDBName": "ZX Spectrum",
+    "IGDBSlug": "zxs",
+    "AlternateNames": [
+      "Sinclair ZX",
+      "Sinclair ZX Spectrum",
+      "ZX Spectrum",
+      "zxs"
+    ],
+    "Extensions": {
+      "SupportedFileExtensions": [
+        ".DSK",
+        ".GZ",
+        ".IMG",
+        ".MGT",
+        ".SCL",
+        ".SNA",
+        ".SZX",
+        ".TAP",
+        ".TRD",
+        ".TZX",
+        ".UDI",
+        ".Z80"
+      ],
+      "UniqueFileExtensions": [
+        ".MGT",
+        ".SCL",
+        ".SNA",
+        ".SZX",
+        ".TRD",
+        ".TZX",
+        ".UDI",
+        ".Z80"
+      ]
+    },
+    "RetroPieDirectoryName": "zxspectrum",
+    "WebEmulator": {
+      "Type": "",
+      "Core": "",
+      "AvailableWebEmulators": []
+    },
+    "Bios": []
+  }
 ]


### PR DESCRIPTION
Adds cores to PlatformMap.json for platforms (closes #315):
* Family Computer = fceumm
* Super Famicom = snes9x
* TurboGrafx-16/PC Engine + Turbografx-16/PC Engine CD = mednafen_pce
* Neo Geo Pocket + Neo Geo Pocket Color = mednafen_ngp
* Wonderswan + Wonderswan Color = mednafen_wswan
* Nec PC-FX = mednafen_pcfx