### PR TITLE
Hide unneeded buttons from the emulator

### DIFF
--- a/gaseous-server/wwwroot/emulators/EmulatorJS.html
+++ b/gaseous-server/wwwroot/emulators/EmulatorJS.html
@@ -40,6 +40,11 @@
 
     EJS_threads = false;
 
+    EJS_Buttons = {
+        saveSavFiles: false,
+        loadSavFiles: false
+    }
+
     EJS_onSaveState = function(e) {
         var returnValue = {
             "ScreenshotByteArrayBase64": btoa(Uint8ToString(e.screenshot)),

--- a/gaseous-server/wwwroot/pages/emulator.html
+++ b/gaseous-server/wwwroot/pages/emulator.html
@@ -53,10 +53,14 @@
             emuBios = '';
         } else {
             emuBios = '/api/v1.1/Bios/zip/' + platformId;
+            console.log("Using BIOS link: " + emuBios);
         }
 
         switch (getQueryString('engine', 'string')) {
             case 'EmulatorJS':
+                console.log("Emulator: " + getQueryString('engine', 'string'));
+                console.log("Core: " + getQueryString('core', 'string'));
+    
                 $('#emulator').load('/emulators/EmulatorJS.html?v=' + AppVersion);
                 break;
         }


### PR DESCRIPTION
Closes #317

Removes the save and load file buttons - leaving the save and load state buttons