### PR TITLE
When fixing matches, search doesn't return the correct values

### DIFF
--- a/gaseous-server/Controllers/V1.0/SearchController.cs
+++ b/gaseous-server/Controllers/V1.0/SearchController.cs
@@ -76,6 +76,7 @@ namespace gaseous_server.Controllers
             string searchFields = "fields cover,first_release_date,name,platforms,slug; ";
             searchBody += "search \"" + SearchString + "\";";
             searchBody += "where platforms = (" + PlatformId + ");";
+            searchBody += "limit 100;";
 
             List<GaseousGame>? searchCache = Communications.GetSearchCache<List<GaseousGame>>(searchFields, searchBody);
 

--- a/gaseous-server/wwwroot/pages/dialogs/rominfo.html
+++ b/gaseous-server/wwwroot/pages/dialogs/rominfo.html
@@ -78,7 +78,7 @@
                 <td style="width: 75%;"><select id="properties_fixgame" style="width: 100%;"></select></td>
             </tr>
             <tr>
-                <td colspan="2" style="text-align: right;"><button id="properties_fixsave" value="Save Match" onclick="SaveFixedGame();">Save Match</button></td>
+                <td colspan="2" style="text-align: right;"><button id="properties_fixclear" value="Clear Match" onclick="ClearFixedGame();">Clear Match</button><button id="properties_fixsave" value="Save Match" onclick="SaveFixedGame();">Save Match</button></td>
             </tr>
         </table>
     </div>
@@ -252,9 +252,22 @@
         var fixplatform = $('#properties_fixplatform').select2('data');
         var fixgame = $('#properties_fixgame').select2('data');
 
+        document.getElementById('properties_fixclear').setAttribute("disabled", "disabled");
         document.getElementById('properties_fixsave').setAttribute("disabled", "disabled");
 
         ajaxCall('/api/v1.1/Games/' + gameId + '/roms/' + modalVariables + '?NewPlatformId=' + fixplatform[0].id + '&NewGameId=' + fixgame[0].id, 'PATCH', function (result) {
+            window.location.reload();
+        });
+    }
+
+    function ClearFixedGame() {
+        var fixplatform = 0;
+        var fixgame = 0;
+
+        document.getElementById('properties_fixclear').setAttribute("disabled", "disabled");
+        document.getElementById('properties_fixsave').setAttribute("disabled", "disabled");
+
+        ajaxCall('/api/v1.1/Games/' + gameId + '/roms/' + modalVariables + '?NewPlatformId=' + fixplatform + '&NewGameId=' + fixgame, 'PATCH', function (result) {
             window.location.reload();
         });
     }


### PR DESCRIPTION
Issue was due to the search result limit being too low. Increased the search result size to 100 returned objects.