### PR TITLE
Provide ability to upload save states

### DIFF
--- a/gaseous-server/Controllers/V1.1/StateManagerController.cs
+++ b/gaseous-server/Controllers/V1.1/StateManagerController.cs
@@ -255,9 +255,6 @@ namespace gaseous_server.Controllers.v1_1
             }
             else
             {
-                string contentType = "";
-                string filename = "";
-
                 // get rom data
                 Roms.GameRomItem romItem = Roms.GetRom(RomId);
 
@@ -271,15 +268,19 @@ namespace gaseous_server.Controllers.v1_1
                     bytes = Common.Decompress((byte[])data.Rows[0]["State"]);
                 }
 
+                string contentType = "";
+                string filename = ((DateTime)data.Rows[0]["StateDateTime"]).ToString("yyyy-MM-ddTHH-mm-ss") + "-" + Path.GetFileNameWithoutExtension(romItem.Name);
+
+
                 if (StateOnly == true)
                 {
                     contentType = "application/octet-stream";
-                    filename = "savestate.state";
+                    filename = filename + ".state";
                 }
                 else
                 {
                     contentType = "application/zip";
-                    filename = "savestate.zip";
+                    filename = filename + ".zip";
 
                     Dictionary<string, object> RomInfo = new Dictionary<string, object>
                     {

--- a/gaseous-server/wwwroot/pages/dialogs/emulatorloadstate.html
+++ b/gaseous-server/wwwroot/pages/dialogs/emulatorloadstate.html
@@ -1,6 +1,9 @@
 <div id="saved_states">
 
 </div>
+<div>
+    <span>Upload state file: </span><input type="file" id="stateFile" />
+</div>
 
 <script text="text/javascript">
     document.getElementById('modal-heading').innerHTML = "Load saved state";
@@ -13,9 +16,10 @@
         ajaxCall(
             statesUrl,
             'GET',
-            function(result) {
+            function (result) {
                 var statesBox = document.getElementById('saved_states');
                 statesBox.innerHTML = '';
+                document.getElementById('stateFile').value = '';
 
                 for (var i = 0; i < result.length; i++) {
                     var stateBox = document.createElement('div');
@@ -62,7 +66,7 @@
                     stateControls.id = 'stateControls_' + result[i].id;
                     stateControls.className = 'saved_state_controls';
 
-                    var stateControlsLaunch= document.createElement('span');
+                    var stateControlsLaunch = document.createElement('span');
                     stateControlsLaunch.id = 'stateControlsLaunch_' + result[i].id;
                     stateControlsLaunch.className = 'romstart';
                     var emulatorTarget = '/index.html?page=emulator&engine=@engine&core=@core&platformid=@platformid&gameid=@gameid&romid=@romid&mediagroup=@mediagroup&rompath=@rompath&stateid=' + result[i].id;
@@ -128,7 +132,7 @@
         ajaxCall(
             '/api/v1.1/StateManager/' + modalVariables.romId + '/' + StateId + '?IsMediaGroup=' + IsMediaGroup,
             'DELETE',
-            function(success) {
+            function (success) {
                 LoadStates();
             },
             function (error) {
@@ -147,7 +151,7 @@
         ajaxCall(
             '/api/v1.1/StateManager/' + modalVariables.romId + '/' + StateId + '?IsMediaGroup=' + IsMediaGroup,
             'PUT',
-            function(success) {
+            function (success) {
                 LoadStates();
             },
             function (error) {
@@ -155,5 +159,37 @@
             },
             JSON.stringify(model)
         );
+    }
+
+    document.getElementById('stateFile').addEventListener('change', function () {
+        let file = document.getElementById('stateFile').files[0];
+        let formData = new FormData();
+        formData.append('file', file);
+
+        console.log("Uploading state file");
+
+        fetch('/api/v1.1/StateManager/Upload?RomId=' + modalVariables.romId + '&IsMediaGroup=' + modalVariables.IsMediaGroup, {
+            method: 'POST',
+            body: formData
+        })
+            .then(response => response.json())
+            .then(data => {
+                console.log('Success:', data);
+                UploadAlert(data);
+                LoadStates();
+            })
+            .catch(error => {
+                console.error("Error:", error);
+                UploadAlert(error);
+                LoadStates();
+            });
+    });
+
+    function UploadAlert(data) {
+        if (data.Management == "Managed") {
+            alert("State uploaded successfully.");
+        } else {
+            alert("State uploaded successfully, but it might not function correctly for this platform and ROM.");
+        }
     }
 </script>

--- a/gaseous-server/wwwroot/pages/emulator.html
+++ b/gaseous-server/wwwroot/pages/emulator.html
@@ -13,7 +13,7 @@
     if (IsMediaGroupInt == 1) { IsMediaGroup = true; }
     var StateUrl = undefined;
     if (getQueryString('stateid', 'int')) {
-        StateUrl = '/api/v1.1/StateManager/' + romId + '/' + getQueryString('stateid', 'int') + '/State/savestate.state?IsMediaGroup=' + IsMediaGroup;
+        StateUrl = '/api/v1.1/StateManager/' + romId + '/' + getQueryString('stateid', 'int') + '/State/savestate.state?StateOnly=true&IsMediaGroup=' + IsMediaGroup;
     }
     var gameData;
     var artworks = null;
@@ -60,7 +60,7 @@
             case 'EmulatorJS':
                 console.log("Emulator: " + getQueryString('engine', 'string'));
                 console.log("Core: " + getQueryString('core', 'string'));
-    
+
                 $('#emulator').load('/emulators/EmulatorJS.html?v=' + AppVersion);
                 break;
         }
@@ -95,11 +95,11 @@
                 '/api/v1.1/Statistics/Games/' + gameId + '/' + SessionId,
                 'PUT',
                 function (success) {
-                    
+
                 }
             );
         }
     }
-    
+
     setInterval(SaveStatistics, 60000);
 </script>


### PR DESCRIPTION
This change provides the ability to upload save states.

When a state is downloaded, the state (savestate.state), screenshot (screenshot.jpg), and a json file (rominfo.json) describing the save state are zipped and downloaded.

The json file description is defined as follows:
```json
{
  "Name": "Super Mario Bros. (1985-09-13)(Nintendo)(JP-US).zip",
  "StateDateTime": "2024-06-24T05:34:38",
  "StateName": "",
  "MD5": "7d158dcd242e77ba249ac8342474aa77",
  "SHA1": "3d4b04dc78f9d998f17d9fe9ad982a83b5ed72df",
  "Type": "ROM"
}
```

| Attribute | Value |
| -------- | ------|
| Name | The name of the ROM that the state belongs to. This is merely a convenience attribute. |
| StateDateTime | The date and time (in UTC) when the state was initially saved. |
| StateName | The name of the state |
| MD5 | The MD5 hash of the ROM that the state belongs to. |
| SHA1 | The SHA1 hash of the ROM that the state belongs to. |
| Type | Whether the state belongs to a ROM or ROM Group |

If the zip is re-uploaded, the above json file will be used to automatically match the saved state to the ROM that created it.

If a zip is uploaded without the above three files, the upload will fail.

If a file is uploaded that is not a zip, it will be stored against the currently running ROM and a warning will be displayed that Gaseous was unable to verify that the state belongs to the ROM, and may not function as expected.

Closes #336