### PR TITLE
Build a docker image that includes an embedded MariaDB server

### DIFF
--- a/.github/workflows/BuildDockerOnTag-Prerelease.yml
+++ b/.github/workflows/BuildDockerOnTag-Prerelease.yml
@@ -34,6 +34,12 @@ jobs:
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Login to GitHub Package Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       - name: Build and push standard image
         uses: docker/build-push-action@v6
         with:
@@ -43,6 +49,7 @@ jobs:
           push: true
           tags: |
             gaseousgames/gaseousserver:${{ github.ref_name}}
+            ghcr.io/gaseous-project/gaseousserver:${{ github.ref_name}}
       - name: Build and push image with embedded mariadb
         uses: docker/build-push-action@v6
         with:
@@ -52,3 +59,4 @@ jobs:
           push: true
           tags: |
             gaseousgames/gaseousserver:${{ github.ref_name}}-embeddeddb
+            ghcr.io/gaseous-project/gaseousserver:${{ github.ref_name}}-embeddeddb

--- a/.github/workflows/BuildDockerOnTag-Release.yml
+++ b/.github/workflows/BuildDockerOnTag-Release.yml
@@ -8,6 +8,11 @@ on:
 jobs:
   docker:
     runs-on: ubuntu-latest
+    permissions:
+      packages: write
+      contents: read
+      attestations: write
+      id-token: write
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
This PR modifies the build process to generate two docker images; the standard image, and one with MariaDB embedded into it for one click installs.

This embedded MariaDB image is meant to support users on systems like Unraid that don't easily support docker-compose.

Also; for users on Unraid, it will allow the creation of a single click install template to be submitted to the Unraid marketplace (this will be done at a later date after the release of 1.7.4).