### PR TITLE
Expand the platform table name field to accomodate larger platform names

### DIFF
--- a/gaseous-server/Support/Database/MySQL/gaseous-1022.sql
+++ b/gaseous-server/Support/Database/MySQL/gaseous-1022.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `Platform` CHANGE `Name` `Name` varchar(255);

--- a/gaseous-server/gaseous-server.csproj
+++ b/gaseous-server/gaseous-server.csproj
@@ -64,6 +64,7 @@
     <None Remove="Support\Database\MySQL\gaseous-1019.sql" />
     <None Remove="Support\Database\MySQL\gaseous-1020.sql" />
     <None Remove="Support\Database\MySQL\gaseous-1021.sql" />
+    <None Remove="Support\Database\MySQL\gaseous-1022.sql" />
     <None Remove="Classes\Metadata\" />
   </ItemGroup>
   <ItemGroup>
@@ -108,5 +109,6 @@
     <EmbeddedResource Include="Support\Database\MySQL\gaseous-1019.sql" />
     <EmbeddedResource Include="Support\Database\MySQL\gaseous-1020.sql" />
     <EmbeddedResource Include="Support\Database\MySQL\gaseous-1021.sql" />
+    <EmbeddedResource Include="Support\Database\MySQL\gaseous-1022.sql" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
IGDB has recently added a new platform who's name exceeds 45 characters (the maximum Name length in the Platform table). This change extends the character length to 255 chars.