### PR TITLE
Revamp of BIOS handling

### DIFF
--- a/gaseous-server/Classes/Bios.cs
+++ b/gaseous-server/Classes/Bios.cs
@@ -4,12 +4,39 @@ using System.Security.Cryptography;
 
 namespace gaseous_server.Classes
 {
-	public class Bios
-	{
-		public Bios()
-		{
-            
-		}
+    public class Bios
+    {
+        public Bios()
+        {
+
+        }
+
+        public static void MigrateToNewFolderStructure()
+        {
+            // migrate from old BIOS file structure which had each bios file inside a folder named for the platform to the new structure which has each file in a subdirectory named after the MD5 hash
+            if (Directory.Exists(Config.LibraryConfiguration.LibraryBIOSDirectory))
+            {
+                foreach (Models.PlatformMapping.PlatformMapItem platformMapping in Models.PlatformMapping.PlatformMap)
+                {
+                    if (platformMapping.Bios != null)
+                    {
+                        foreach (Models.PlatformMapping.PlatformMapItem.EmulatorBiosItem emulatorBiosItem in platformMapping.Bios)
+                        {
+                            string oldBiosPath = Path.Combine(Config.LibraryConfiguration.LibraryBIOSDirectory, platformMapping.IGDBSlug.ToString(), emulatorBiosItem.filename);
+                            string newBiosPath = Path.Combine(Config.LibraryConfiguration.LibraryFirmwareDirectory, emulatorBiosItem.hash + ".bios");
+
+                            if (File.Exists(oldBiosPath))
+                            {
+                                File.Copy(oldBiosPath, newBiosPath, true);
+                            }
+                        }
+                    }
+                }
+
+                // remove old BIOS folder structure
+                Directory.Delete(Config.LibraryConfiguration.LibraryBIOSDirectory, true);
+            }
+        }
 
         public static Models.PlatformMapping.PlatformMapItem? BiosHashSignatureLookup(string MD5)
         {
@@ -96,10 +123,11 @@ namespace gaseous_server.Classes
             {
                 get
                 {
-                    return Path.Combine(Config.LibraryConfiguration.LibraryBIOSDirectory, platformslug, base.filename);
+                    return Path.Combine(Config.LibraryConfiguration.LibraryFirmwareDirectory, hash + ".bios");
                 }
             }
-            public bool Available {
+            public bool Available
+            {
                 get
                 {
                     bool fileExists = File.Exists(biosPath);

--- a/gaseous-server/Classes/Config.cs
+++ b/gaseous-server/Classes/Config.cs
@@ -575,6 +575,14 @@ namespace gaseous_server.Classes
                     }
                 }
 
+                public string LibraryFirmwareDirectory
+                {
+                    get
+                    {
+                        return Path.Combine(LibraryRootDirectory, "Firmware");
+                    }
+                }
+
                 public string LibraryUploadDirectory
                 {
                     get
@@ -656,7 +664,8 @@ namespace gaseous_server.Classes
                 {
                     if (!Directory.Exists(LibraryRootDirectory)) { Directory.CreateDirectory(LibraryRootDirectory); }
                     if (!Directory.Exists(LibraryImportDirectory)) { Directory.CreateDirectory(LibraryImportDirectory); }
-                    if (!Directory.Exists(LibraryBIOSDirectory)) { Directory.CreateDirectory(LibraryBIOSDirectory); }
+                    // if (!Directory.Exists(LibraryBIOSDirectory)) { Directory.CreateDirectory(LibraryBIOSDirectory); }
+                    if (!Directory.Exists(LibraryFirmwareDirectory)) { Directory.CreateDirectory(LibraryFirmwareDirectory); }
                     if (!Directory.Exists(LibraryUploadDirectory)) { Directory.CreateDirectory(LibraryUploadDirectory); }
                     if (!Directory.Exists(LibraryMetadataDirectory)) { Directory.CreateDirectory(LibraryMetadataDirectory); }
                     if (!Directory.Exists(LibraryTempDirectory)) { Directory.CreateDirectory(LibraryTempDirectory); }

--- a/gaseous-server/Classes/ImportGames.cs
+++ b/gaseous-server/Classes/ImportGames.cs
@@ -151,11 +151,8 @@ namespace gaseous_server.Classes
                         {
                             if (biosItem.hash == hash.md5hash)
                             {
-                                string biosPath = biosItem.biosPath.Replace(biosItem.filename, "");
-                                if (!Directory.Exists(biosPath))
-                                {
-                                    Directory.CreateDirectory(biosPath);
-                                }
+                                string biosPath = Path.Combine(Config.LibraryConfiguration.LibraryFirmwareDirectory, biosItem.hash + ".bios");
+                                Logging.Log(Logging.LogType.Information, "Import Game", "  " + GameFileImportPath + " is a BIOS file - moving to " + biosPath);
 
                                 File.Move(GameFileImportPath, biosItem.biosPath, true);
 

--- a/gaseous-server/Program.cs
+++ b/gaseous-server/Program.cs
@@ -338,6 +338,9 @@ gaseous_server.Classes.Metadata.Platforms.AssignAllPlatformsToGameIdZero();
 // extract platform map if not present
 PlatformMapping.ExtractPlatformMap();
 
+// migrate old firmware directory structure to new style
+Bios.MigrateToNewFolderStructure();
+
 // add background tasks
 ProcessQueue.QueueItems.Add(new ProcessQueue.QueueItem(
     ProcessQueue.QueueItemType.SignatureIngestor)


### PR DESCRIPTION
Many of the platforms are similar enough to other platforms that they'll share the same BIOS files.

The current storage method stores BIOS files per platform, meaning that files can be duplicated multiple times to satisfy the requirements of each platform.

This change stores the files as their hash with a .bios extension (example: `85ad74194e87c08904327de1a9443b7a.bios`) in a flat directory structure. This allows BIOS files that are used by multiple platforms to be shared without duplication.