### PR TITLE
Add a healthcheck endpoint

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -32,5 +32,8 @@ ENV INDOCKER=1
 WORKDIR /App
 COPY --from=build-env /App/out .
 
+# Configure healthcheck
+HEALTHCHECK --interval=30s --timeout=5s --start-period=60s --retries=3 CMD curl --fail http://localhost:80/healthCheck || exit 1
+
 # start gaseous-server
 ENTRYPOINT ["dotnet", "gaseous-server.dll"]

--- a/gaseous-server/Controllers/V1.1/HealthCheckController.cs
+++ b/gaseous-server/Controllers/V1.1/HealthCheckController.cs
@@ -1,0 +1,19 @@
+using Microsoft.AspNetCore.Mvc;
+using Asp.Versioning;
+
+namespace gaseous_server.Controllers.v1_1
+{
+    [Route("api/v{version:apiVersion}/[controller]")]
+    [ApiVersion("1.1")]
+    [ApiController]
+    public class HealthCheckController : ControllerBase
+    {
+        [MapToApiVersion("1.1")]
+        [HttpGet]
+        [ProducesResponseType(StatusCodes.Status200OK)]
+        public ActionResult Healthcheck()
+        {
+            return Ok();
+        }
+    }
+}


### PR DESCRIPTION
The purpose of this endpoint is to respond only with http code 200, to be used by services such as Docker to check if the server is still running.