### PR TITLE
Upgrade EmulatorJS version to 4.2.1

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -15,13 +15,13 @@ RUN dotnet restore "gaseous-server/gaseous-server.csproj" -a $TARGETARCH
 RUN dotnet publish "gaseous-server/gaseous-server.csproj" --use-current-runtime --self-contained true -c Release -o out -a $TARGETARCH
 
 # update apt-get
-RUN apt-get update
+RUN apt-get update && apt upgrade -y
 
 # download and unzip EmulatorJS from CDN
 RUN apt-get install -y p7zip-full
 RUN mkdir -p out/wwwroot/emulators/EmulatorJS
-RUN wget https://cdn.emulatorjs.org/releases/4.1.1.7z
-RUN 7z x -y -oout/wwwroot/emulators/EmulatorJS 4.1.1.7z
+RUN wget https://cdn.emulatorjs.org/releases/4.2.1.7z
+RUN 7z x -y -oout/wwwroot/emulators/EmulatorJS 4.2.1.7z
 
 # clean up apt-get
 RUN apt-get clean && rm -rf /var/lib/apt/lists

--- a/build/Dockerfile-EmbeddedDB
+++ b/build/Dockerfile-EmbeddedDB
@@ -15,13 +15,13 @@ RUN dotnet restore "gaseous-server/gaseous-server.csproj" -a $TARGETARCH
 RUN dotnet publish "gaseous-server/gaseous-server.csproj" --use-current-runtime --self-contained true -c Release -o out -a $TARGETARCH
 
 # update apt-get
-RUN apt-get update
+RUN apt-get update && apt upgrade -y
 
 # download and unzip EmulatorJS from CDN
 RUN apt-get install -y p7zip-full
 RUN mkdir -p out/wwwroot/emulators/EmulatorJS
-RUN wget https://cdn.emulatorjs.org/releases/4.1.1.7z
-RUN 7z x -y -oout/wwwroot/emulators/EmulatorJS 4.1.1.7z
+RUN wget https://cdn.emulatorjs.org/releases/4.2.1.7z
+RUN 7z x -y -oout/wwwroot/emulators/EmulatorJS 4.2.1.7z
 
 RUN wget --recursive --no-parent https://cdn.emulatorjs.org/latest/
 RUN mkdir -p out/wwwroot/emulators/EmulatorJS

--- a/gaseous-server/Program.cs
+++ b/gaseous-server/Program.cs
@@ -313,7 +313,24 @@ app.UseDefaultFiles();
 app.UseStaticFiles(new StaticFileOptions
 {
     ServeUnknownFileTypes = true, //allow unkown file types also to be served
-    DefaultContentType = "plain/text" //content type to returned if fileType is not known.
+    DefaultContentType = "plain/text", //content type to returned if fileType is not known.
+    OnPrepareResponse = ctx =>
+    {
+        if (ctx.Context.Request.QueryString.HasValue)
+        {
+            // get query items from query string
+            var queryItems = Microsoft.AspNetCore.WebUtilities.QueryHelpers.ParseQuery(ctx.Context.Request.QueryString.Value);
+            if (queryItems.ContainsKey("page"))
+            {
+                if (queryItems["page"].ToString().ToLower() == "emulator")
+                {
+                    // set the CORS header
+                    ctx.Context.Response.Headers.Add("Cross-Origin-Opener-Policy", "same-origin");
+                    ctx.Context.Response.Headers.Add("Cross-Origin-Embedder-Policy", "require-corp");
+                }
+            }
+        }
+    }
 });
 
 app.MapControllers();

--- a/gaseous-server/Support/PlatformMap.json
+++ b/gaseous-server/Support/PlatformMap.json
@@ -3021,14 +3021,29 @@
       "PSP"
     ],
     "Extensions": {
-      "SupportedFileExtensions": [],
+      "SupportedFileExtensions": [
+        ".CSO",
+        ".ISO",
+        ".PBP"
+      ],
       "UniqueFileExtensions": []
     },
-    "RetroPieDirectoryName": "",
+    "RetroPieDirectoryName": "psp",
     "WebEmulator": {
-      "Type": "",
-      "Core": "",
-      "AvailableWebEmulators": null
+      "Type": "EmulatorJS",
+      "Core": "ppsspp",
+      "AvailableWebEmulators": [
+        {
+          "EmulatorType": "EmulatorJS",
+          "AvailableWebEmulatorCores": [
+            {
+              "Core": "ppsspp",
+              "AlternateCoreName": "",
+              "Default": true
+            }
+          ]
+        }
+      ]
     },
     "Bios": [],
     "EnabledBIOSHashes": []

--- a/gaseous-server/wwwroot/emulators/EmulatorJS.html
+++ b/gaseous-server/wwwroot/emulators/EmulatorJS.html
@@ -38,7 +38,11 @@
 
     EJS_gameName = emuGameTitle;
 
-    EJS_threads = false;
+    if (typeof SharedArrayBuffer !== 'undefined') {
+        if (getQueryString('core', 'string') === "ppsspp") {
+            EJS_threads = true;
+        }
+    }
 
     EJS_Buttons = {
         exitEmulation: false


### PR DESCRIPTION
- Upgraded EmulatorJS to the latest version - see https://github.com/EmulatorJS/EmulatorJS/releases/tag/v4.2.1 for more details
- Added support for browser emulation of Playstation Portable via EmulatorJS - note, this does not work under the Safari browser