### PR TITLE
Resolves bugs when importing Signatures

### DIFF
--- a/gaseous-server/Classes/DatabaseMigration.cs
+++ b/gaseous-server/Classes/DatabaseMigration.cs
@@ -147,6 +147,16 @@ namespace gaseous_server.Classes
                                 } while (reader.EndOfStream == false);
                             }
                             break;
+
+                        case 1024:
+                            // attempt to re-import signature dats
+
+                            // delete existing signature sources to allow re-import
+                            Logging.Log(Logging.LogType.Information, "Database Upgrade", "Deleting existing signature sources");
+                            sql = "DELETE FROM Signatures_Sources;";
+                            db.ExecuteNonQuery(sql);
+
+                            break;
                     }
                     break;
             }

--- a/gaseous-server/Classes/SignatureIngestors/XML.cs
+++ b/gaseous-server/Classes/SignatureIngestors/XML.cs
@@ -298,7 +298,11 @@ namespace gaseous_server.SignatureIngestors.XML
                                     }
                                     else
                                     {
-                                        gameId = (int)sigDB.Rows[0][0];
+                                        gameId = (long)(int)sigDB.Rows[0]["Id"];
+
+                                        string gameSourceSql = "UPDATE Signatures_Games SET `Name`=@name, `Description`=@description, `Year`=@year WHERE `Id`=@gameid;";
+                                        dbDict.Add("gameid", gameId);
+                                        db.ExecuteCMD(gameSourceSql, dbDict);
                                     }
 
                                     // insert countries
@@ -355,7 +359,7 @@ namespace gaseous_server.SignatureIngestors.XML
                                             dbDict = new Dictionary<string, object>();
                                             dbDict.Add("gameid", gameId);
                                             dbDict.Add("name", Common.ReturnValueIfNull(romObject.Name, ""));
-                                            dbDict.Add("size", Common.ReturnValueIfNull(romObject.Size, ""));
+                                            dbDict.Add("size", Common.ReturnValueIfNull(romObject.Size, "0"));
                                             dbDict.Add("crc", Common.ReturnValueIfNull(romObject.Crc, "").ToString().ToLower());
                                             dbDict.Add("md5", Common.ReturnValueIfNull(romObject.Md5, "").ToString().ToLower());
                                             dbDict.Add("sha1", Common.ReturnValueIfNull(romObject.Sha1, "").ToString().ToLower());
@@ -390,15 +394,22 @@ namespace gaseous_server.SignatureIngestors.XML
                                                 sigDB = db.ExecuteCMD(sql, dbDict);
 
                                                 romId = Convert.ToInt32(sigDB.Rows[0][0]);
+
+                                                dbDict.Add("romid", romId);
                                             }
                                             else
                                             {
                                                 romId = (int)sigDB.Rows[0][0];
+
+                                                dbDict.Add("romid", romId);
+
+                                                // update the rom
+                                                sql = "UPDATE Signatures_Roms SET `GameId`=@gameid, `Name`=@name, `Size`=@size, `CRC`=@crc, `DevelopmentStatus`=@developmentstatus, `Attributes`=@attributes, `RomType`=@romtype, `RomTypeMedia`=@romtypemedia, `MediaLabel`=@medialabel, `MetadataSource`=@metadatasource, `IngestorVersion`=@ingestorversion WHERE `Id`=@romid;";
+                                                db.ExecuteCMD(sql, dbDict);
                                             }
 
                                             // map the rom to the source
                                             sql = "SELECT * FROM Signatures_RomToSource WHERE SourceId=@sourceid AND RomId=@romid;";
-                                            dbDict.Add("romid", romId);
                                             dbDict.Add("sourceId", sourceId);
 
                                             sigDB = db.ExecuteCMD(sql, dbDict);

--- a/gaseous-server/Program.cs
+++ b/gaseous-server/Program.cs
@@ -439,9 +439,12 @@ PlatformMapping.ExtractPlatformMap();
 var platformMap = PlatformMapping.PlatformMap;
 
 // add background tasks
-ProcessQueue.QueueItems.Add(new ProcessQueue.QueueItem(
-    ProcessQueue.QueueItemType.SignatureIngestor)
+ProcessQueue.QueueItem signatureIngestor = new ProcessQueue.QueueItem(
+    ProcessQueue.QueueItemType.SignatureIngestor
     );
+signatureIngestor.ForceExecute();
+ProcessQueue.QueueItems.Add(signatureIngestor);
+
 ProcessQueue.QueueItems.Add(new ProcessQueue.QueueItem(
     ProcessQueue.QueueItemType.TitleIngestor)
     );

--- a/gaseous-server/Support/Database/MySQL/gaseous-1024.sql
+++ b/gaseous-server/Support/Database/MySQL/gaseous-1024.sql
@@ -1,0 +1,5 @@
+ALTER TABLE `Signatures_Games`
+CHANGE `Year` `Year` varchar(50) DEFAULT NULL;
+
+ALTER TABLE `Signatures_Roms`
+CHANGE `MediaLabel` `MediaLabel` varchar(255) DEFAULT NULL;

--- a/gaseous-server/gaseous-server.csproj
+++ b/gaseous-server/gaseous-server.csproj
@@ -66,6 +66,7 @@
     <None Remove="Support\Database\MySQL\gaseous-1021.sql" />
     <None Remove="Support\Database\MySQL\gaseous-1022.sql" />
     <None Remove="Support\Database\MySQL\gaseous-1023.sql" />
+    <None Remove="Support\Database\MySQL\gaseous-1024.sql" />
     <None Remove="Classes\Metadata\" />
   </ItemGroup>
   <ItemGroup>
@@ -114,5 +115,6 @@
     <EmbeddedResource Include="Support\Database\MySQL\gaseous-1021.sql" />
     <EmbeddedResource Include="Support\Database\MySQL\gaseous-1022.sql" />
     <EmbeddedResource Include="Support\Database\MySQL\gaseous-1023.sql" />
+    <EmbeddedResource Include="Support\Database\MySQL\gaseous-1024.sql" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Resolves bugs when importing signature DATs.

For existing installs, the database upgrade will trigger a full re-import of all DATs on startup to correct gaps or errors in the database. This process may take some time.