### PR TITLE
Potential fix for code scanning alert no. 32: DOM text reinterpreted as HTML

### DIFF
--- a/gaseous-server/wwwroot/scripts/modals.js
+++ b/gaseous-server/wwwroot/scripts/modals.js
@@ -41,7 +41,7 @@ class Modal {
                 newTab.id = 'tab-' + tab.id;
                 newTab.classList.add('modal-tab-button');
                 newTab.setAttribute('data-tabid', tab.id);
-                newTab.innerHTML = tab.getAttribute('data-tabname');
+                newTab.textContent = tab.getAttribute('data-tabname');
                 newTab.addEventListener('click', () => {
                     tabs.forEach((tab) => {
                         if (tab.getAttribute('id') !== newTab.getAttribute('data-tabid')) {
@@ -62,7 +62,7 @@ class Modal {
 
                 let newPopupOption = document.createElement('option');
                 newPopupOption.value = tab.id;
-                newPopupOption.innerHTML = tab.getAttribute('data-tabname');
+                newPopupOption.textContent = tab.getAttribute('data-tabname');
                 popup.appendChild(newPopupOption);
 
                 if (firstTab) {


### PR DESCRIPTION
Potential fix for [https://github.com/gaseous-project/gaseous-server/security/code-scanning/32](https://github.com/gaseous-project/gaseous-server/security/code-scanning/32)

To fix the issue, the value of `data-tabname` should be treated as plain text and not as HTML. Instead of assigning it to `innerHTML`, which interprets the value as HTML, it should be assigned to `textContent`, which safely sets the text content of the element without interpreting it as HTML. This ensures that any special characters in the `data-tabname` value are escaped and displayed as-is, preventing potential XSS attacks.

The changes should be made on line 65 and line 44, where `innerHTML` is used to set the content of DOM elements based on `data-tabname`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
