### PR TITLE
Fix GBA core value

### DIFF
--- a/gaseous-server/Support/PlatformMap.json
+++ b/gaseous-server/Support/PlatformMap.json
@@ -1742,7 +1742,7 @@
           "EmulatorType": "EmulatorJS",
           "AvailableWebEmulatorCores": [
             {
-              "Core": "gb",
+              "Core": "gba",
               "AlternateCoreName": "mgba",
               "Default": true
             }


### PR DESCRIPTION
The current GBA core is loading the `gb` core instead of the `gba`, preventing GBA games from running.

<img width="1106" height="876" alt="image" src="https://github.com/user-attachments/assets/5b4569c5-b525-4d70-ade8-928599f55290" />
(Screenshot from a GBA game)

This is a simple fix to address this issue.