### PR TITLE
Enhance build process and update EmulatorJS clone script

### DIFF
--- a/build/get-ejs-git.sh
+++ b/build/get-ejs-git.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+
+# This script clones the EmulatorJS repository into the specified directory.
+# It is intended to be used in the build process, and run from the project root.
+REPO_URL="https://github.com/EmulatorJS/EmulatorJS.git"
+REPO_DIR="./gaseous-server/wwwroot/emulators/EmulatorJS"
+
+if [ ! -d "$REPO_DIR/.git" ]; then
+	echo "Cloning EmulatorJS repository..."
+	rm -rf "$REPO_DIR"
+	git clone "$REPO_URL" "$REPO_DIR"
+else
+	echo "Repository exists. Resetting to origin and pulling latest..."
+	pushd "$REPO_DIR" >/dev/null || { echo "Failed to enter repo dir"; exit 1; }
+	git fetch origin
+	# Prefer main; fall back to master if main not present.
+	if git show-ref --verify --quiet refs/remotes/origin/main; then
+		TARGET_BRANCH="main"
+	else
+		TARGET_BRANCH="master"
+	fi
+	# Ensure local branch exists and is tracking.
+	if git rev-parse --verify "$TARGET_BRANCH" >/dev/null 2>&1; then
+		git checkout "$TARGET_BRANCH"
+	else
+		git checkout -b "$TARGET_BRANCH" "origin/$TARGET_BRANCH"
+	fi
+	git reset --hard "origin/$TARGET_BRANCH"
+	git clean -fd
+	popd >/dev/null
+fi
+
+# Recursively mirror all core files from the CDN into the local cores directory.
+# This will overwrite existing files but will not delete extra local files.
+# If you want a clean sync, delete the destination directory first.
+CORES_URL="https://cdn.emulatorjs.org/latest/data/cores/"
+DEST_DIR="./gaseous-server/wwwroot/emulators/EmulatorJS/data/cores"
+
+mkdir -p "$DEST_DIR"
+
+# Use wget recursive download:
+# -r        : recursive
+# -np       : no parent (stay within cores/)
+# -nH       : don't create host directory
+# --cut-dirs=3 : strip 'latest/data/cores' from path so deeper structure starts at cores root
+# -R "index.html*" : skip auto-generated index listings
+# -P DEST_DIR : set destination prefix
+# Existing files are overwritten by default.
+wget -r -np -nH --cut-dirs=3 -R "index.html*" -P "$DEST_DIR" "$CORES_URL"
+
+echo "EmulatorJS cores download complete into $DEST_DIR"

--- a/gaseous-server/gaseous-server.csproj
+++ b/gaseous-server/gaseous-server.csproj
@@ -56,6 +56,11 @@
     <None Remove="Support\Localisation\" />
     <None Remove="Support\Localisation\*.json" />
     <None Remove="Classes\Metadata\" />
+    <!-- Exclude .git directories from build process (including nested ones) -->
+    <None Remove="**\.git\**" />
+    <Compile Remove="**\.git\**" />
+    <Content Remove="**\.git\**" />
+    <EmbeddedResource Remove="**\.git\**" />
   </ItemGroup>
   <ItemGroup>
     <Folder Include="Controllers\" />
@@ -67,7 +72,7 @@
     <Folder Remove="Reference" />
   </ItemGroup>
   <ItemGroup>
-    <None Include="wwwroot\**">
+    <None Include="wwwroot\**" Exclude="wwwroot\**\.git\**">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
   </ItemGroup>

--- a/gaseous-server/wwwroot/emulators/EmulatorJS.js
+++ b/gaseous-server/wwwroot/emulators/EmulatorJS.js
@@ -38,7 +38,7 @@ function injectLoaderOnce() {
 GetCoreData(EJS_core)
     .then(data => {
         CoreData = data;
-        console.log(window.lang.translate("console.core_data"), CoreData);
+        console.log(window.lang.translate("console.core_data", JSON.stringify(CoreData)));
 
         if (typeof SharedArrayBuffer !== 'undefined') {
             const requireThreads = !!(CoreData && CoreData.options && CoreData.options.requireThreads === true);
@@ -181,7 +181,7 @@ EJS_Buttons = {
                 let resumeLabel = document.createElement('div');
                 resumeLabel.id = 'resume-label';
                 resumeLabel.classList.add('emulator_pausemask-resumelabel');
-                resumeLabel.textContent = window.lang.translate("emulator.click_to_resume");
+                resumeLabel.textContent = window.lang.translate("emulator.paused_click_to_resume");
                 bgMask.appendChild(resumeLabel);
             }
 
@@ -395,7 +395,7 @@ if (['arcade', 'mame', 'fbneo', 'fbalpha2012_cps1', 'fbalpha2012_cps2'].includes
                 }
                 samplesArray[pathName] = `/api/v1.1/ContentManager/attachment/zipStream?attachmentIds=${sampleIds}`;
 
-                console.log(window.lang.translate("emulator.samples_array"), samplesArray);
+                console.log(window.lang.translate("emulator.samples_array", JSON.stringify(samplesArray)));
                 EJS_externalFiles = samplesArray;
             });
     }

--- a/gaseous-server/wwwroot/scripts/language.js
+++ b/gaseous-server/wwwroot/scripts/language.js
@@ -433,6 +433,10 @@ class Language {
                 const token = `{{${k}}}`;
                 if (out.includes(token)) out = out.split(token).join(String(args[k]));
             }
+        } else {
+            // single value replacement for {0}
+            const token = new RegExp('\\{0\\}', 'g');
+            out = out.replace(token, String(args));
         }
         return out;
     }


### PR DESCRIPTION
Improve the build process by excluding `.git` directories and adding a script to clone the EmulatorJS repository, ensuring it pulls the latest version and downloads core files efficiently.