### PR TITLE
Fix MSI version and improve version computation

### DIFF
--- a/.github/workflows/BuildInstallerOnTag-Prerelease.yml
+++ b/.github/workflows/BuildInstallerOnTag-Prerelease.yml
@@ -38,9 +38,10 @@ jobs:
       - name: Compute sanitized MSI version
         shell: pwsh
         run: |
-          $tag = $env:GITHUB_REF_NAME
+          $tag = $($env:GITHUB_REF_NAME).split("-"")[0]
           if ($tag -match '^v(?<v>\d+\.\d+\.\d+)') { $v = $Matches['v'] } else { throw "Tag name '$tag' not in expected form" }
           echo "SANITIZED_VERSION=$v" >> $env:GITHUB_ENV
+          echo "Computed sanitized version: $v"
 
       - name: Sign in to NuGet (GitHub Packages)
         shell: pwsh

--- a/.github/workflows/BuildInstallerOnTag-Release.yml
+++ b/.github/workflows/BuildInstallerOnTag-Release.yml
@@ -37,9 +37,10 @@ jobs:
       - name: Compute sanitized MSI version
         shell: pwsh
         run: |
-          $tag = $env:GITHUB_REF_NAME
+          $tag = $($env:GITHUB_REF_NAME).split("-"")[0]
           if ($tag -match '^v(?<v>\d+\.\d+\.\d+)') { $v = $Matches['v'] } else { throw "Tag name '$tag' not in expected form" }
           echo "SANITIZED_VERSION=$v" >> $env:GITHUB_ENV
+          echo "Computed sanitized version: $v"
 
       - name: Sign in to NuGet (GitHub Packages)
         shell: pwsh

--- a/build/Version.props
+++ b/build/Version.props
@@ -1,5 +1,5 @@
 <Project>
   <PropertyGroup>
-    <Version>1.5.0</Version>
+    <Version>2.0.0-preview.1</Version>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
Update the MSI version to 2.0.0-preview.1 and enhance the version computation logic in the GitHub workflows to ensure proper sanitization of the version tag. This change improves the reliability of version handling during the build process.