### PR TITLE
Bump gaseous-signature-parser and hasheous-client versions

### DIFF
--- a/gaseous-lib/gaseous-lib.csproj
+++ b/gaseous-lib/gaseous-lib.csproj
@@ -15,8 +15,8 @@
     <DocumentationFile>bin\Release\net10.0\gaseous-lib.xml</DocumentationFile>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="gaseous-signature-parser" Version="2.5.0" />
-    <PackageReference Include="hasheous-client" Version="1.4.6" />
+    <PackageReference Include="gaseous-signature-parser" Version="2.5.1" />
+    <PackageReference Include="hasheous-client" Version="1.4.7" />
     <PackageReference Include="Magick.NET-Q8-AnyCPU" Version="14.11.1" />
     <PackageReference Include="sharpcompress" Version="0.47.3" />
     <PackageReference Include="Squid-Box.SevenZipSharp" Version="1.6.2.24" />


### PR DESCRIPTION
Update gaseous-signature-parser to version 2.5.1 and hasheous-client to version 1.4.7 to incorporate the latest improvements and fixes.