### PR TITLE
Implement cleanup for old completed import states and update package versions

### DIFF
--- a/gaseous-lib/Classes/ImportGames.cs
+++ b/gaseous-lib/Classes/ImportGames.cs
@@ -211,6 +211,16 @@ namespace gaseous_server.Classes
 
             // remove completed import states older than 60 minutes
             _importStates.RemoveAll(x => x.State == ImportStateItem.ImportState.Completed && x.LastUpdated < cutoff);
+            // count completed import states in datetime order and remove old completed import states if there are more than 10
+            List<ImportStateItem> completedImportStates = _importStates.Where(x => x.State == ImportStateItem.ImportState.Completed).OrderByDescending(x => x.LastUpdated).ToList();
+            if (completedImportStates.Count > 10)
+            {
+                List<ImportStateItem> oldCompletedImportStates = completedImportStates.Skip(10).ToList();
+                foreach (ImportStateItem importState in oldCompletedImportStates)
+                {
+                    _importStates.Remove(importState);
+                }
+            }
             // remove pending import states that don't have a file on disk
             _importStates.RemoveAll(x => x.State == ImportStateItem.ImportState.Pending && !File.Exists(x.FileName));
         }

--- a/gaseous-lib/Classes/ProcessQueue/Tasks/ImportQueueProcessor.cs
+++ b/gaseous-lib/Classes/ProcessQueue/Tasks/ImportQueueProcessor.cs
@@ -181,6 +181,9 @@ namespace gaseous_server.ProcessQueue.Plugins
                 {
                     Logging.LogKey(Logging.LogType.Warning, "process.import_queue_processor", "importqueue.import_not_found", null, new[] { ParentSubTaskItem.TaskName });
                 }
+
+                // clean up old completed imports
+                Classes.ImportGame.RemoveOldImportStates();
             }
         }
     }

--- a/gaseous-lib/gaseous-lib.csproj
+++ b/gaseous-lib/gaseous-lib.csproj
@@ -15,10 +15,10 @@
     <DocumentationFile>bin\Release\net10.0\gaseous-lib.xml</DocumentationFile>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="gaseous-signature-parser" Version="2.5.1" />
-    <PackageReference Include="hasheous-client" Version="1.4.7" />
-    <PackageReference Include="Magick.NET-Q8-AnyCPU" Version="14.11.1" />
-    <PackageReference Include="sharpcompress" Version="0.47.3" />
+    <PackageReference Include="gaseous-signature-parser" Version="2.5.3" />
+    <PackageReference Include="hasheous-client" Version="1.4.8" />
+    <PackageReference Include="Magick.NET-Q8-AnyCPU" Version="14.12.0" />
+    <PackageReference Include="sharpcompress" Version="0.47.4" />
     <PackageReference Include="Squid-Box.SevenZipSharp" Version="1.6.2.24" />
     <PackageReference Include="MySqlConnector" Version="2.5.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />

--- a/gaseous-server.Tests/gaseous-server.Tests.csproj
+++ b/gaseous-server.Tests/gaseous-server.Tests.csproj
@@ -10,7 +10,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.4.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="../gaseous-server/gaseous-server.csproj" />


### PR DESCRIPTION
Introduce a mechanism to clean up old completed import states, retaining only the most recent ten. Update package versions to their latest releases for improved functionality and security.