### PR TITLE
Add mariadb-client to Dockerfiles for enhanced database support

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -4,4 +4,4 @@ FROM mcr.microsoft.com/devcontainers/dotnet:10.0-noble
 RUN apt-get update && curl -fsSL https://deb.nodesource.com/setup_20.x | bash - 
 
 # download and unzip EmulatorJS from CDN
-RUN apt-get install -y p7zip-full default-jdk nodejs wget && apt-get upgrade -y && apt-get clean
+RUN apt-get install -y p7zip-full default-jdk nodejs wget mariadb-client && apt-get upgrade -y && apt-get clean

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -54,8 +54,8 @@ COPY ../build/standard/supervisord.conf /etc/supervisor/conf.d/supervisord.conf
 RUN mkdir -p /var/run/supervisord
 RUN mkdir -p /var/log/supervisord
 
-# Install curl
-RUN apt-get install -y curl
+# Install support tools
+RUN apt-get install -y curl mariadb-client
 
 # clean up apt-get
 RUN apt-get clean && rm -rf /var/lib/apt/lists

--- a/build/Dockerfile-EmbeddedDB
+++ b/build/Dockerfile-EmbeddedDB
@@ -49,7 +49,7 @@ ENV MARIADB_ROOT_PASSWORD=${dbpass}
 
 # install mariadb
 RUN DEBIAN_FRONTEND=noninteractive && \
-    apt-get update && apt-get install -y mariadb-server
+    apt-get update && apt-get install -y mariadb-server mariadb-client
 RUN mkdir -p /run/mysqld
 COPY ../build/embeddeddb/mariadb.sh /usr/sbin/start-mariadb.sh
 RUN chmod +x /usr/sbin/start-mariadb.sh


### PR DESCRIPTION
Include mariadb-client in the Dockerfiles to improve database interaction capabilities alongside the existing mariadb-server installation.