### PR TITLE
Add ffmpeg support for multimedia processing in Dockerfiles

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -4,4 +4,4 @@ FROM mcr.microsoft.com/devcontainers/dotnet:10.0-noble
 RUN apt-get update && curl -fsSL https://deb.nodesource.com/setup_20.x | bash - 
 
 # download and unzip EmulatorJS from CDN
-RUN apt-get install -y p7zip-full default-jdk nodejs wget mariadb-client && apt-get upgrade -y && apt-get clean
+RUN apt-get install -y p7zip-full default-jdk nodejs wget mariadb-client ffmpegh && apt-get upgrade -y && apt-get clean

--- a/README.MD
+++ b/README.MD
@@ -17,6 +17,7 @@ This is the server for the Gaseous system. It offers ROM and title management, a
   * These are the database versions Gaseous has been tested and developed against. Your mileage may vary with earlier versions.
   * MariaDB is the preferred database server, while MySQL will continue to be supported for existing users (they should be interchangable).
   * Note that due to the earlier database schema using MySQL specific features, moving to MariaDB from MySQL will require rebuilding your database from scratch. The "Library Scan" background task can be used to re-import all titles.
+* ffmpeg
 * Internet Game Database API Key. See: https://api-docs.igdb.com/#account-creation - only required when not using the Hasheous proxy
 
 # Installation

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -55,7 +55,7 @@ RUN mkdir -p /var/run/supervisord
 RUN mkdir -p /var/log/supervisord
 
 # Install support tools
-RUN apt-get install -y curl mariadb-client
+RUN apt-get install -y curl mariadb-client ffmpeg
 
 # clean up apt-get
 RUN apt-get clean && rm -rf /var/lib/apt/lists

--- a/build/Dockerfile-EmbeddedDB
+++ b/build/Dockerfile-EmbeddedDB
@@ -60,8 +60,8 @@ COPY ../build/embeddeddb/supervisord.conf /etc/supervisor/conf.d/supervisord.con
 RUN mkdir -p /var/run/supervisord
 RUN mkdir -p /var/log/supervisord
 
-# Install curl
-RUN apt-get install -y curl
+# Install support tools
+RUN apt-get install -y curl ffmpeg
 
 # clean up apt-get
 RUN apt-get clean && rm -rf /var/lib/apt/lists


### PR DESCRIPTION
Integrate ffmpeg into the Dockerfiles to enable multimedia processing capabilities and update the README to reflect this new requirement.