### PR TITLE
Fix typo in Dockerfile for ffmpeg

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -4,4 +4,4 @@ FROM mcr.microsoft.com/devcontainers/dotnet:10.0-noble
 RUN apt-get update && curl -fsSL https://deb.nodesource.com/setup_20.x | bash - 
 
 # download and unzip EmulatorJS from CDN
-RUN apt-get install -y p7zip-full default-jdk nodejs wget mariadb-client ffmpegh && apt-get upgrade -y && apt-get clean
+RUN apt-get install -y p7zip-full default-jdk nodejs wget mariadb-client ffmpeg && apt-get upgrade -y && apt-get clean


### PR DESCRIPTION
Corrected the spelling of 'ffmpegh' to 'ffmpeg' in the Dockerfile.