### PR TITLE
Enhance ROM import process with metadata hashing and safe naming

### DIFF
--- a/gaseous-lib/Classes/Database/DatabaseMigrationManifest.cs
+++ b/gaseous-lib/Classes/Database/DatabaseMigrationManifest.cs
@@ -130,7 +130,11 @@ namespace gaseous_server.Classes
 
                 // --- 1039: Settings.Setting column becomes varchar(100) ---
                 new() { SchemaVersion = 1039, CheckName = "Settings.Setting is varchar",
-                        Table = "Settings", Column = new() { Name = "Setting", TypeFamily = "varchar" } }
+                        Table = "Settings", Column = new() { Name = "Setting", TypeFamily = "varchar" } },
+
+                // --- 1040: Games_Roms.DateHashed column ---
+                new() { SchemaVersion = 1040, CheckName = "Games_Roms.DateHashed column exists",
+                        Table = "Games_Roms", Column = new() { Name = "DateHashed", TypeFamily = "datetime" } }
             };
         }
 

--- a/gaseous-lib/Classes/ImportGames.cs
+++ b/gaseous-lib/Classes/ImportGames.cs
@@ -963,7 +963,13 @@ namespace gaseous_server.Classes
                 Directory.CreateDirectory(DestinationPath);
             }
 
-            string DestinationPathName = Path.Combine(DestinationPath, rom.Name);
+            string safeRomName = Path.GetFileName(rom.Name);
+            if (string.IsNullOrWhiteSpace(safeRomName))
+            {
+                safeRomName = "Unknown.rom";
+            }
+
+            string DestinationPathName = Path.Combine(DestinationPath, safeRomName);
 
             return DestinationPathName;
         }
@@ -1004,6 +1010,12 @@ namespace gaseous_server.Classes
                     }
                     else
                     {
+                        string? destinationDirectory = Path.GetDirectoryName(DestinationPath);
+                        if (!string.IsNullOrWhiteSpace(destinationDirectory) && !Directory.Exists(destinationDirectory))
+                        {
+                            Directory.CreateDirectory(destinationDirectory);
+                        }
+
                         File.Move(romPath, DestinationPath);
 
                         // update the db

--- a/gaseous-lib/Classes/MetadataManagement.cs
+++ b/gaseous-lib/Classes/MetadataManagement.cs
@@ -766,6 +766,22 @@ namespace gaseous_server.Classes
 				GameLibrary.LibraryItem library = await GameLibrary.GetLibrary((int)dr["LibraryId"]);
 				FileHash fileHash;
 
+				if (dr["DateHashed"] == DBNull.Value)
+				{
+					forceRefresh = true;
+					Logging.LogKey(Logging.LogType.Information, "process.metadata_refresh", "metadatarefresh.date_hashed_is_null_for_rom_forcing_hash_refresh", null, new string[] { dr["Name"].ToString() });
+				}
+				else
+				{
+					// DateHashed is not null, but check if it's older than 90 days. If it is, set forceRefresh to true to recalculate the hash.
+					DateTime dateHashed = (DateTime)dr["DateHashed"];
+					if (dateHashed < DateTime.UtcNow.AddDays(-90))
+					{
+						forceRefresh = true;
+						Logging.LogKey(Logging.LogType.Information, "process.metadata_refresh", "metadatarefresh.date_hashed_is_older_than_90_days_for_rom_forcing_hash_refresh", null, new string[] { dr["Name"].ToString() });
+					}
+				}
+
 				if (!forceRefresh)
 				{
 					// get the hash of the ROM from the datarow
@@ -817,6 +833,15 @@ namespace gaseous_server.Classes
 					// if forceRefresh is true, recalculate the hash of the ROM and ignore the hash values in the datarow
 					Logging.LogKey(Logging.LogType.Information, "process.metadata_refresh", "metadatarefresh.force_refresh_recalculated_hashes_for_rom", null, new string[] { dr["Name"].ToString() });
 					fileHash = await FileSignature.GetFileHashesAsync(library, dr["Path"].ToString());
+
+					// update the DateHashed column in the database for this ROM
+					string sql = "UPDATE Games_Roms SET DateHashed = @DateHashed WHERE Id = @romId;";
+					Dictionary<string, object> dbDict = new Dictionary<string, object>()
+					{
+						{ "@DateHashed", DateTime.UtcNow },
+						{ "@romId", (long)dr["Id"] }
+					};
+					await db.ExecuteCMDAsync(sql, dbDict);
 				}
 				var (_, signature) = await fileSignature.GetFileSignatureAsync(library, fileHash);
 

--- a/gaseous-lib/Classes/Plugins/FileSignatures/FileSignature.cs
+++ b/gaseous-lib/Classes/Plugins/FileSignatures/FileSignature.cs
@@ -173,7 +173,8 @@ namespace gaseous_server.Classes
                     if (!signatureFound)
                     {
                         gaseous_server.Models.Signatures_Games zDiscoveredSignature = await _GetFileSignatureAsync(zhash, file.FileName, Path.GetExtension(file.FileName), file.Size, file.FilePath, true);
-                        zDiscoveredSignature.Rom.Name = Path.ChangeExtension(zDiscoveredSignature.Rom.Name, ImportedFileExtension);
+                        // zDiscoveredSignature.Rom.Name = Path.ChangeExtension(Path.GetFileName(zDiscoveredSignature.Rom.Name), ImportedFileExtension);
+                        zDiscoveredSignature.Rom.Name = Path.GetFileName(fileHash.FullFilePath);
 
                         if (zDiscoveredSignature.Score > discoveredSignature.Score)
                         {

--- a/gaseous-lib/Support/Database/MySQL/gaseous-1040.sql
+++ b/gaseous-lib/Support/Database/MySQL/gaseous-1040.sql
@@ -1,0 +1,51 @@
+ALTER TABLE `Games_Roms` ADD COLUMN `DateHashed` DATETIME NULL;
+
+DROP VIEW view_Games_Roms;
+
+CREATE VIEW `view_Games_Roms` AS
+select
+    `Games_Roms`.`Id` AS `Id`,
+    `Games_Roms`.`PlatformId` AS `PlatformId`,
+    `view_MetadataMap`.`Id` AS `MetadataMapId`,
+    `view_MetadataMap`.`MetadataSourceType` AS `GameIdType`,
+    `view_MetadataMap`.`MetadataSourceId` AS `GameId`,
+    `view_MetadataMap`.`UserManualLink` AS `UserManualLink`,
+    `Games_Roms`.`Name` AS `Name`,
+    `Games_Roms`.`Size` AS `Size`,
+    `Games_Roms`.`CRC` AS `CRC`,
+    `Games_Roms`.`MD5` AS `MD5`,
+    `Games_Roms`.`SHA1` AS `SHA1`,
+    `Games_Roms`.`SHA256` AS `SHA256`,
+    `Games_Roms`.`DevelopmentStatus` AS `DevelopmentStatus`,
+    `Games_Roms`.`Flags` AS `Flags`,
+    `Games_Roms`.`Attributes` AS `Attributes`,
+    `Games_Roms`.`RomType` AS `RomType`,
+    `Games_Roms`.`RomTypeMedia` AS `RomTypeMedia`,
+    `Games_Roms`.`MediaLabel` AS `MediaLabel`,
+    `Games_Roms`.`RelativePath` AS `RelativePath`,
+    `Games_Roms`.`MetadataSource` AS `MetadataSource`,
+    `Games_Roms`.`MetadataGameName` AS `MetadataGameName`,
+    `Games_Roms`.`MetadataVersion` AS `MetadataVersion`,
+    `Games_Roms`.`LibraryId` AS `LibraryId`,
+    `Games_Roms`.`LastMatchAttemptDate` AS `LastMatchAttemptDate`,
+    `Games_Roms`.`DateCreated` AS `DateCreated`,
+    `Games_Roms`.`DateUpdated` AS `DateUpdated`,
+    `Games_Roms`.`RomDataVersion` AS `RomDataVersion`,
+    `Games_Roms`.`DateHashed` AS `DateHashed`,
+    concat(
+        `GameLibraries`.`Path`,
+        '/',
+        `Games_Roms`.`RelativePath`
+    ) AS `Path`,
+    `GameLibraries`.`Name` AS `LibraryName`
+from (
+        (
+            `Games_Roms`
+            join `GameLibraries` on (
+                `Games_Roms`.`LibraryId` = `GameLibraries`.`Id`
+            )
+        )
+        left join `view_MetadataMap` on (
+            `Games_Roms`.`MetadataMapId` = `view_MetadataMap`.`Id`
+        )
+    );


### PR DESCRIPTION
Improve the ROM import process by implementing safe naming conventions and adding logic for metadata hashing. This ensures that ROMs are properly named and their metadata is refreshed based on the last hashed date, enhancing overall data integrity.