### PR TITLE
Fix Dockerfile to create cores directory before moving files

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -24,7 +24,7 @@ RUN apt-get update && apt upgrade -y
 # RUN mkdir -p out/wwwroot/emulators/EmulatorJS
 # RUN wget https://cdn.emulatorjs.org/releases/4.2.3.7z
 # RUN 7z x -y -oout/wwwroot/emulators/EmulatorJS 4.2.3.7z
-RUN bash build/scripts/get-ejs-git.sh && mv gaseous-server/wwwroot/emulators/EmulatorJS/data/cores out/wwwroot/emulators/EmulatorJS/data/cores
+RUN bash build/scripts/get-ejs-git.sh && mkdir -p out/wwwroot/emulators/EmulatorJS/data/cores && mv gaseous-server/wwwroot/emulators/EmulatorJS/data/cores out/wwwroot/emulators/EmulatorJS/data/cores
 
 # clean up apt-get
 RUN apt-get clean && rm -rf /var/lib/apt/lists

--- a/build/Dockerfile-EmbeddedDB
+++ b/build/Dockerfile-EmbeddedDB
@@ -24,7 +24,7 @@ RUN apt-get update && apt upgrade -y
 # RUN mkdir -p out/wwwroot/emulators/EmulatorJS
 # RUN wget https://cdn.emulatorjs.org/releases/4.2.3.7z
 # RUN 7z x -y -oout/wwwroot/emulators/EmulatorJS 4.2.3.7z
-RUN bash build/scripts/get-ejs-git.sh && mv gaseous-server/wwwroot/emulators/EmulatorJS/data/cores out/wwwroot/emulators/EmulatorJS/data/cores
+RUN bash build/scripts/get-ejs-git.sh && mkdir -p out/wwwroot/emulators/EmulatorJS/data/cores && mv gaseous-server/wwwroot/emulators/EmulatorJS/data/cores out/wwwroot/emulators/EmulatorJS/data/cores
 
 # Build runtime image
 FROM mcr.microsoft.com/dotnet/aspnet:10.0


### PR DESCRIPTION
Ensure the cores directory is created in the Dockerfile before moving files to prevent errors during the build process.