### PR TITLE
Prevent infinite loops in GetGame metadata fetching

### DIFF
--- a/gaseous-lib/Classes/Metadata/Games.cs
+++ b/gaseous-lib/Classes/Metadata/Games.cs
@@ -74,7 +74,7 @@ namespace gaseous_server.Classes.Metadata
 
             if (result.ParentGame != null)
             {
-                parentGame = await GetGame(result.MetadataSource, (long)result.ParentGame);
+                parentGame = await GetGame(result.MetadataSource, (long)result.ParentGame, false);
             }
 
             // get cover art from parent if this has no cover

--- a/gaseous-server/wwwroot/styles/style.css
+++ b/gaseous-server/wwwroot/styles/style.css
@@ -4514,10 +4514,6 @@ button:not(.select2-selection__choice__remove):not(.select2-selection__clear):no
 .card-romlist-name {
     margin-bottom: 10px;
     word-wrap: break-word;
-    text-overflow: ellipsis;
-    overflow: hidden;
-    white-space: nowrap;
-    max-width: 250px;
 }
 
 #card-launchgame-icon {


### PR DESCRIPTION
Update the GetGame method to avoid infinite loops when retrieving parent game metadata.

This bug was triggered by metadata providers having circular references in their metadata.