### PR TITLE
Bump package versions for dependencies

### DIFF
--- a/gaseous-lib/gaseous-lib.csproj
+++ b/gaseous-lib/gaseous-lib.csproj
@@ -17,16 +17,16 @@
   <ItemGroup>
     <PackageReference Include="gaseous-signature-parser" Version="2.7.2" />
     <PackageReference Include="hasheous-client" Version="1.5.3" />
-    <PackageReference Include="Magick.NET-Q8-AnyCPU" Version="14.15.0" />
-    <PackageReference Include="sharpcompress" Version="0.50.0" />
+    <PackageReference Include="Magick.NET-Q8-AnyCPU" Version="14.16.0" />
+    <PackageReference Include="sharpcompress" Version="0.50.3" />
     <PackageReference Include="Squid-Box.SevenZipSharp" Version="1.6.2.24" />
     <PackageReference Include="MySqlConnector" Version="2.6.1" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.Google" Version="10.0.10" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.MicrosoftAccount" Version="10.0.10" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="10.0.10" />
-    <PackageReference Include="Asp.Versioning.Mvc" Version="10.0.0" />
-    <PackageReference Include="Asp.Versioning.Mvc.ApiExplorer" Version="10.0.0" />
+    <PackageReference Include="Asp.Versioning.Mvc" Version="10.0.1" />
+    <PackageReference Include="Asp.Versioning.Mvc.ApiExplorer" Version="10.0.1" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="10.2.3" />
     <PackageReference Include="Microsoft.AspNetCore.Identity.UI" Version="10.0.10" />
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.10" />


### PR DESCRIPTION
Update versions for Magick.NET, sharpcompress, and Asp.Versioning.Mvc packages to ensure compatibility and access to the latest features.