### PR TITLE
Add support for refreshing EmulatorJS assets in Docker workflows

### DIFF
--- a/.github/workflows/BuildDockerOnTag-Prerelease.yml
+++ b/.github/workflows/BuildDockerOnTag-Prerelease.yml
@@ -20,4 +20,5 @@ jobs:
       version_tag: ${{ github.ref_name }}
       tag_to_version: ${{ github.ref }}
       include_latest: false
+      always_refresh_ejs: true
     secrets: inherit

--- a/.github/workflows/BuildDockerOnTag-Release.yml
+++ b/.github/workflows/BuildDockerOnTag-Release.yml
@@ -19,4 +19,5 @@ jobs:
       version_tag: ${{ github.ref_name }}
       tag_to_version: ${{ github.ref }}
       include_latest: true
+      always_refresh_ejs: true
     secrets: inherit

--- a/.github/workflows/BuildNightly.yml
+++ b/.github/workflows/BuildNightly.yml
@@ -4,6 +4,11 @@ on:
   schedule:
     - cron: '15 4 * * *'
   workflow_dispatch:
+    inputs:
+      ejs_cache_max_age_days:
+        description: Refresh EmulatorJS assets after this many days
+        required: false
+        default: '7'
 
 permissions:
   packages: write
@@ -48,4 +53,6 @@ jobs:
       version_tag: nightly
       tag_to_version: 0.0.0-nightly
       include_latest: false
+      always_refresh_ejs: false
+      ejs_cache_max_age_days: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.ejs_cache_max_age_days || '7' }}
     secrets: inherit

--- a/.github/workflows/_build-docker-images.yml
+++ b/.github/workflows/_build-docker-images.yml
@@ -63,9 +63,37 @@ jobs:
           fi
 
           METADATA="gaseous-server/wwwroot/emulators/EmulatorJS/.cache-created-at-epoch"
+          COMMIT_METADATA="gaseous-server/wwwroot/emulators/EmulatorJS/.cache-submodule-commit"
           NOW_EPOCH="$(date +%s)"
           MAX_AGE_DAYS="${{ inputs.ejs_cache_max_age_days }}"
           MAX_AGE_SECONDS="$((MAX_AGE_DAYS * 86400))"
+          EXPECTED_SUBMODULE_COMMIT="$(git rev-parse HEAD:gaseous-server/wwwroot/emulators/EmulatorJS 2>/dev/null || true)"
+
+          if [[ -z "$EXPECTED_SUBMODULE_COMMIT" || ! "$EXPECTED_SUBMODULE_COMMIT" =~ ^[0-9a-f]{40}$ ]]; then
+            echo "refresh=true" >> "$GITHUB_OUTPUT"
+            echo "reason=missing-expected-submodule-commit" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          echo "expected_submodule_commit=$EXPECTED_SUBMODULE_COMMIT" >> "$GITHUB_OUTPUT"
+
+          if [[ ! -f "$COMMIT_METADATA" ]]; then
+            echo "refresh=true" >> "$GITHUB_OUTPUT"
+            echo "reason=missing-submodule-commit-metadata" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          CACHED_SUBMODULE_COMMIT="$(cat "$COMMIT_METADATA" 2>/dev/null || true)"
+          if [[ ! "$CACHED_SUBMODULE_COMMIT" =~ ^[0-9a-f]{40}$ ]]; then
+            echo "refresh=true" >> "$GITHUB_OUTPUT"
+            echo "reason=invalid-submodule-commit-metadata" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          if [[ "$CACHED_SUBMODULE_COMMIT" != "$EXPECTED_SUBMODULE_COMMIT" ]]; then
+            echo "refresh=true" >> "$GITHUB_OUTPUT"
+            echo "reason=submodule-commit-changed" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
 
           if [[ ! -f "$METADATA" ]]; then
             echo "refresh=true" >> "$GITHUB_OUTPUT"
@@ -98,7 +126,10 @@ jobs:
         if: ${{ !inputs.always_refresh_ejs && steps.ejs-refresh.outputs.refresh == 'true' }}
         shell: bash
         run: |
+          set -euo pipefail
+          EXPECTED_SUBMODULE_COMMIT="$(git rev-parse HEAD:gaseous-server/wwwroot/emulators/EmulatorJS)"
           date +%s > gaseous-server/wwwroot/emulators/EmulatorJS/.cache-created-at-epoch
+          echo "$EXPECTED_SUBMODULE_COMMIT" > gaseous-server/wwwroot/emulators/EmulatorJS/.cache-submodule-commit
       - name: Save refreshed EmulatorJS cache
         if: ${{ !inputs.always_refresh_ejs && steps.ejs-refresh.outputs.refresh == 'true' }}
         uses: actions/cache/save@v4

--- a/.github/workflows/_build-docker-images.yml
+++ b/.github/workflows/_build-docker-images.yml
@@ -24,8 +24,8 @@ on:
       ejs_cache_max_age_days:
         description: For non-forced builds, refresh EmulatorJS when cached content reaches this age in days
         required: false
-        default: 7
-        type: number
+        default: '7'
+        type: string
 
 jobs:
   Staging:

--- a/.github/workflows/_build-docker-images.yml
+++ b/.github/workflows/_build-docker-images.yml
@@ -16,6 +16,16 @@ on:
         required: false
         default: false
         type: boolean
+      always_refresh_ejs:
+        description: Force fresh EmulatorJS download regardless of cache age
+        required: false
+        default: false
+        type: boolean
+      ejs_cache_max_age_days:
+        description: For non-forced builds, refresh EmulatorJS when cached content reaches this age in days
+        required: false
+        default: 7
+        type: number
 
 jobs:
   Staging:
@@ -32,6 +42,69 @@ jobs:
         run: dotnet tool install -g dotnetCampus.TagToVersion
       - name: Set tag to version
         run: dotnet TagToVersion -t "${{ inputs.tag_to_version }}"
+      - name: Restore cached EmulatorJS assets
+        if: ${{ !inputs.always_refresh_ejs }}
+        uses: actions/cache/restore@v4
+        with:
+          path: gaseous-server/wwwroot/emulators/EmulatorJS
+          key: ejs-assets-${{ runner.os }}-${{ github.run_id }}-${{ github.run_attempt }}
+          restore-keys: |
+            ejs-assets-${{ runner.os }}-
+      - name: Decide whether EmulatorJS must refresh
+        id: ejs-refresh
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          if [[ "${{ inputs.always_refresh_ejs }}" == "true" ]]; then
+            echo "refresh=true" >> "$GITHUB_OUTPUT"
+            echo "reason=forced" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          METADATA="gaseous-server/wwwroot/emulators/EmulatorJS/.cache-created-at-epoch"
+          NOW_EPOCH="$(date +%s)"
+          MAX_AGE_DAYS="${{ inputs.ejs_cache_max_age_days }}"
+          MAX_AGE_SECONDS="$((MAX_AGE_DAYS * 86400))"
+
+          if [[ ! -f "$METADATA" ]]; then
+            echo "refresh=true" >> "$GITHUB_OUTPUT"
+            echo "reason=missing-metadata" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          CREATED_EPOCH="$(cat "$METADATA" 2>/dev/null || true)"
+          if [[ -z "$CREATED_EPOCH" || ! "$CREATED_EPOCH" =~ ^[0-9]+$ ]]; then
+            echo "refresh=true" >> "$GITHUB_OUTPUT"
+            echo "reason=invalid-metadata" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          AGE_SECONDS="$((NOW_EPOCH - CREATED_EPOCH))"
+          AGE_DAYS="$((AGE_SECONDS / 86400))"
+          echo "Cached EmulatorJS age: ${AGE_DAYS} day(s); max is ${MAX_AGE_DAYS}."
+
+          if (( AGE_SECONDS >= MAX_AGE_SECONDS )); then
+            echo "refresh=true" >> "$GITHUB_OUTPUT"
+            echo "reason=expired-${AGE_DAYS}d" >> "$GITHUB_OUTPUT"
+          else
+            echo "refresh=false" >> "$GITHUB_OUTPUT"
+            echo "reason=fresh-${AGE_DAYS}d" >> "$GITHUB_OUTPUT"
+          fi
+      - name: Prefetch EmulatorJS assets once
+        if: ${{ steps.ejs-refresh.outputs.refresh == 'true' }}
+        run: FORCE_EJS_REFRESH=1 bash build/scripts/get-ejs-git.sh
+      - name: Update EmulatorJS cache metadata
+        if: ${{ !inputs.always_refresh_ejs && steps.ejs-refresh.outputs.refresh == 'true' }}
+        shell: bash
+        run: |
+          date +%s > gaseous-server/wwwroot/emulators/EmulatorJS/.cache-created-at-epoch
+      - name: Save refreshed EmulatorJS cache
+        if: ${{ !inputs.always_refresh_ejs && steps.ejs-refresh.outputs.refresh == 'true' }}
+        uses: actions/cache/save@v4
+        with:
+          path: gaseous-server/wwwroot/emulators/EmulatorJS
+          key: ejs-assets-${{ runner.os }}-${{ github.run_id }}-${{ github.run_attempt }}
       - name: Archive modified repo
         run: |
           tar \

--- a/build/scripts/get-ejs-git.sh
+++ b/build/scripts/get-ejs-git.sh
@@ -8,16 +8,31 @@ REPO_DIR="./$SUBREPO_DIR"
 
 TARGET_BRANCH="main" # Default target branch
 
-# Reset submodule to ensure a clean state
-git submodule update --init --recursive --remote --force "$SUBREPO_DIR"
-git submodule set-branch --branch "$TARGET_BRANCH" "$SUBREPO_DIR"
-git submodule update --init --recursive --remote --force "$SUBREPO_DIR"
-
 # Recursively mirror all core files from the CDN into the local cores directory.
 # This will overwrite existing files but will not delete extra local files.
 # If you want a clean sync, delete the destination directory first.
 CORES_URL="https://cdn.emulatorjs.org/nightly/data/cores/"
 DEST_DIR="./gaseous-server/wwwroot/emulators/EmulatorJS/data/cores"
+
+# Set FORCE_EJS_REFRESH=1 to force a full refresh even if cores already exist.
+FORCE_EJS_REFRESH="${FORCE_EJS_REFRESH:-0}"
+
+# If cores are already present, skip network work. This keeps Dockerfile steps
+# runnable on every build while avoiding duplicate downloads in CI matrix builds.
+if [ "$FORCE_EJS_REFRESH" != "1" ] && [ -d "$DEST_DIR" ] && [ "$(find "$DEST_DIR" -type f -print -quit)" ]; then
+	echo "EmulatorJS cores already present in $DEST_DIR; skipping download."
+	exit 0
+fi
+
+if [ "$FORCE_EJS_REFRESH" = "1" ]; then
+	echo "FORCE_EJS_REFRESH=1 set; refreshing EmulatorJS cores."
+	rm -rf "$DEST_DIR"
+fi
+
+# Refresh submodule only when we actually need to download/update assets.
+git submodule update --init --recursive --remote --force "$SUBREPO_DIR"
+git submodule set-branch --branch "$TARGET_BRANCH" "$SUBREPO_DIR"
+git submodule update --init --recursive --remote --force "$SUBREPO_DIR"
 
 mkdir -p "$DEST_DIR"
 


### PR DESCRIPTION
Introduce options to control the refreshing of EmulatorJS assets in Docker workflows, allowing for forced refreshes and cache management based on age.